### PR TITLE
fix: correct fee asset ID for Optimism

### DIFF
--- a/.changeset/sharp-toes-tie.md
+++ b/.changeset/sharp-toes-tie.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/bridge-sdk": patch
+---
+
+Fix incorrect fee asset ID for Optimism

--- a/packages/bridge-sdk/src/bridges/hot-bridge/hot-bridge-utils.ts
+++ b/packages/bridge-sdk/src/bridges/hot-bridge/hot-bridge-utils.ts
@@ -10,7 +10,7 @@ export function getFeeAssetIdForChain(caip2: CAIP2_NETWORK) {
 		case CAIP2_NETWORK.TON:
 			return "nep245:v2_1.omni.hot.tg:1117_";
 		case CAIP2_NETWORK.Optimism:
-			return "nep245:v2_1.omni.hot.tg:10_vLAiSt9KfUGKpw5cD3vsSyNYBo7";
+			return "nep245:v2_1.omni.hot.tg:10_11111111111111111111";
 		default:
 			throw new Error(`Unsupported chain = ${caip2}`);
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the fee asset ID used for transactions on the Optimism network to ensure accurate fee handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->