### PR TITLE
fix(bridge-sdk): correct NEAR native asset withdrawal estimation logic

### DIFF
--- a/.changeset/wild-books-fail.md
+++ b/.changeset/wild-books-fail.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/bridge-sdk": patch
+---
+
+Fix estimating native NEAR withdrawal

--- a/packages/bridge-sdk/src/bridges/direct-bridge/direct-bridge.ts
+++ b/packages/bridge-sdk/src/bridges/direct-bridge/direct-bridge.ts
@@ -95,7 +95,7 @@ export class DirectBridge implements Bridge {
 		assert(standard === "nep141", "Only NEP-141 is supported");
 
 		// We don't directly withdraw `wrap.near`, we unwrap it first, so it doesn't require storage
-		if (tokenAccountId === NEAR_NATIVE_ASSET_ID) {
+		if (args.withdrawalParams.assetId === NEAR_NATIVE_ASSET_ID) {
 			return {
 				amount: 0n,
 				quote: null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of withdrawal fee estimation for native NEAR token withdrawals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->