### PR TITLE
feat: support Sui and Aptos networks in POA bridge

### DIFF
--- a/.changeset/late-cars-leave.md
+++ b/.changeset/late-cars-leave.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/bridge-sdk": patch
+---
+
+Add support for Sui and Aptos networks in the POA bridge

--- a/packages/bridge-sdk/src/bridges/poa-bridge/poa-bridge-utils.ts
+++ b/packages/bridge-sdk/src/bridges/poa-bridge/poa-bridge-utils.ts
@@ -51,6 +51,8 @@ const caip2Mapping = {
 	[CAIP2_NETWORK.Gnosis]: "eth:100",
 	[CAIP2_NETWORK.Berachain]: "eth:80094",
 	[CAIP2_NETWORK.Tron]: "tron:mainnet",
+	[CAIP2_NETWORK.Sui]: "sui:mainnet",
+	[CAIP2_NETWORK.Aptos]: "aptos:mainnet",
 } satisfies Record<
 	string,
 	(typeof poaBridge.PoaBridgeNetworkReference)[Exclude<
@@ -78,6 +80,8 @@ const tokenPrefixMapping = {
 	gnosis: CAIP2_NETWORK.Gnosis,
 	bera: CAIP2_NETWORK.Berachain,
 	tron: CAIP2_NETWORK.Tron,
+	sui: CAIP2_NETWORK.Sui,
+	aptos: CAIP2_NETWORK.Aptos,
 };
 
 export function contractIdToCaip2(contractId: string): CAIP2_NETWORK {

--- a/packages/bridge-sdk/src/lib/caip2.ts
+++ b/packages/bridge-sdk/src/lib/caip2.ts
@@ -16,6 +16,8 @@ export const CAIP2_NETWORK = {
 	TON: "tvm:-239",
 	Optimism: "eip155:10",
 	Avalanche: "eip155:43114",
+	Sui: "sui:mainnet",
+	Aptos: "aptos:mainnet",
 } as const;
 
 export type CAIP2_NETWORK = (typeof CAIP2_NETWORK)[keyof typeof CAIP2_NETWORK];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Sui and Aptos blockchain networks in the POA bridge component, enabling interoperability and bridging capabilities with these networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->