### PR TITLE
fix: correct lookup in validateMinWithdrawalAmount and apply linter fixes

### DIFF
--- a/.changeset/mean-tips-lead.md
+++ b/.changeset/mean-tips-lead.md
@@ -1,0 +1,6 @@
+---
+"@defuse-protocol/internal-utils": patch
+"@defuse-protocol/bridge-sdk": patch
+---
+
+Fix minimum withdrawal validation for POA bridge tokens by ensuring the correct token identifier (`defuse_asset_identifier`) is used in `validateMinWithdrawalAmount`. Also, format the `files` array in `package.json` for both packages to a more compact style.

--- a/packages/bridge-sdk/package.json
+++ b/packages/bridge-sdk/package.json
@@ -15,9 +15,7 @@
 			"default": "./dist/index.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"test": "vitest --passWithNoTests",
 		"build": "tsup",

--- a/packages/bridge-sdk/src/bridges/poa-bridge/poa-bridge.ts
+++ b/packages/bridge-sdk/src/bridges/poa-bridge/poa-bridge.ts
@@ -106,7 +106,7 @@ export class PoaBridge implements Bridge {
 		);
 
 		const tokenInfo = tokens.find(
-			(token) => token.intents_token_id === args.assetId,
+			(token) => token.defuse_asset_identifier === args.assetId,
 		);
 
 		if (tokenInfo != null) {

--- a/packages/internal-utils/package.json
+++ b/packages/internal-utils/package.json
@@ -15,9 +15,7 @@
 			"default": "./dist/index.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"scripts": {
 		"test": "vitest --passWithNoTests",
 		"build": "tsup",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the minimum withdrawal validation for POA bridge tokens to ensure accurate token identification.

* **Style**
  * Updated formatting of the "files" field in package settings for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->