### PR TITLE
feat(bridge-sdk): add config for Stellar Horizon and Soroban servers

### DIFF
--- a/.changeset/all-beans-lick.md
+++ b/.changeset/all-beans-lick.md
@@ -1,0 +1,6 @@
+---
+"@defuse-protocol/bridge-sdk": minor
+---
+
+Bump `@hot-labs/omni-sdk` to v2.16.0.
+Change Stellar RPC URL configuration to include both Horizon and Soroban servers.

--- a/packages/bridge-sdk/package.json
+++ b/packages/bridge-sdk/package.json
@@ -32,7 +32,7 @@
 	"dependencies": {
 		"@defuse-protocol/contract-types": "workspace:*",
 		"@defuse-protocol/internal-utils": "workspace:*",
-		"@hot-labs/omni-sdk": "2.14.0",
+		"@hot-labs/omni-sdk": "2.16.0",
 		"@isaacs/ttlcache": "^1.0.0",
 		"@lifeomic/attempt": "^3.0.0",
 		"@scure/base": "^1.0.0",

--- a/packages/bridge-sdk/src/constants/public-rpc-urls.ts
+++ b/packages/bridge-sdk/src/constants/public-rpc-urls.ts
@@ -1,5 +1,6 @@
 import type { HotBridgeEVMChain } from "../bridges/hot-bridge/hot-bridge-chains";
 import { Chains } from "../lib/caip2";
+import type { RPCEndpointMap } from "../shared-types";
 
 /**
  * Default EVM RPC endpoints for HOT bridge supported chains
@@ -11,4 +12,7 @@ export const PUBLIC_EVM_RPC_URLS: Record<HotBridgeEVMChain, string[]> = {
 	[Chains.Avalanche]: ["https://avalanche-c-chain-rpc.publicnode.com"],
 };
 
-export const PUBLIC_STELLAR_RPC_URLS = ["https://mainnet.sorobanrpc.com"];
+export const PUBLIC_STELLAR_RPC_URLS: RPCEndpointMap[typeof Chains.Stellar] = {
+	soroban: ["https://mainnet.sorobanrpc.com"],
+	horizon: ["https://horizon.stellar.org"],
+};

--- a/packages/bridge-sdk/src/lib/configure-rpc-config.ts
+++ b/packages/bridge-sdk/src/lib/configure-rpc-config.ts
@@ -1,10 +1,11 @@
 import { assert } from "@defuse-protocol/internal-utils";
-import { getEIP155ChainId } from "./caip2";
+import type { RPCEndpointMap } from "../shared-types";
+import { Chains, getEIP155ChainId } from "./caip2";
 import { pick } from "./object";
 
 export function configureEvmRpcUrls(
 	defaultRpcUrls: Record<string, string[]>,
-	userRpcUrls: Record<string, string[]> | undefined,
+	userRpcUrls: Partial<RPCEndpointMap> | undefined,
 	supportedChains: string[],
 ): Record<number, string[]> {
 	const evmRpcUrls: Record<number, string[]> = Object.fromEntries(
@@ -22,4 +23,20 @@ export function configureEvmRpcUrls(
 		);
 	}
 	return evmRpcUrls;
+}
+
+export function configureStellarRpcUrls(
+	defaultRpcUrls: RPCEndpointMap[typeof Chains.Stellar],
+	userRpcUrls: Partial<RPCEndpointMap> | undefined,
+) {
+	const stellarRpcUrls = Object.assign(
+		{},
+		defaultRpcUrls,
+		userRpcUrls?.[Chains.Stellar] ?? {},
+	);
+	for (const [key, value] of Object.entries(stellarRpcUrls)) {
+		assert(value.length > 0, `Stellar RPC URL for ${key} is not provided`);
+	}
+
+	return stellarRpcUrls;
 }

--- a/packages/bridge-sdk/src/shared-types.ts
+++ b/packages/bridge-sdk/src/shared-types.ts
@@ -3,11 +3,12 @@ import type {
 	RetryOptions,
 	solverRelay,
 } from "@defuse-protocol/internal-utils";
+import type { HotBridgeEVMChain } from "./bridges/hot-bridge/hot-bridge-chains";
 import type { BridgeNameEnumValues } from "./constants/bridge-name-enum";
 import type { RouteEnum } from "./constants/route-enum";
 import type { IIntentSigner } from "./intents/interfaces/intent-signer";
 import type { IntentPrimitive } from "./intents/shared-types";
-import type { Chain } from "./lib/caip2";
+import type { Chain, Chains } from "./lib/caip2";
 
 export interface IBridgeSDK {
 	setIntentSigner(signer: IIntentSigner): void;
@@ -196,3 +197,13 @@ export type ParsedAssetInfo = (
 	  }
 ) &
 	({ native: true } | { address: string });
+
+export type RPCEndpointMap = Record<
+	typeof Chains.Near | HotBridgeEVMChain,
+	string[]
+> & {
+	[K in typeof Chains.Stellar]: {
+		soroban: string[];
+		horizon: string[];
+	};
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: workspace:*
         version: link:../internal-utils
       '@hot-labs/omni-sdk':
-        specifier: 2.14.0
-        version: 2.14.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
+        specifier: 2.16.0
+        version: 2.16.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@isaacs/ttlcache':
         specifier: ^1.0.0
         version: 1.4.1
@@ -731,8 +731,8 @@ packages:
   '@fivebinaries/coin-selection@3.0.0':
     resolution: {integrity: sha512-h25Pn1ZA7oqQBQDodGAgIsQt66T2wDge9onBKNqE66WNWL0KJiKJbpij8YOLo5AAlEIg5IS7EB1QjBgDOIg6DQ==}
 
-  '@hot-labs/omni-sdk@2.14.0':
-    resolution: {integrity: sha512-AjGol0QmACDN0ODXxkSRrSUKaA3oYOPtARiu/L6gcNL+NLJCl/tRWYiz0cQ1OEp6kP24u8R1VFbL0CkXbQTVFA==}
+  '@hot-labs/omni-sdk@2.16.0':
+    resolution: {integrity: sha512-OQAxiNGOuczEk5LIMfIcnDpNG28RPGmn/kgWuj/Z6Y7OV0vDwBypYlDkiMZZ+s5DyabCrVObbr0Qc6jjRb+Ddg==}
 
   '@hot-labs/omni-sdk@2.8.3':
     resolution: {integrity: sha512-T5cZ8KNDwQdaHFgiM3lg0N4V+FW00jGMmJAL8c0hlbepDTrV064BqqdCtEtPzfgi99DFhgLv+JgyKoc1h5oZOg==}
@@ -4469,7 +4469,7 @@ snapshots:
       '@emurgo/cardano-serialization-lib-browser': 13.2.1
       '@emurgo/cardano-serialization-lib-nodejs': 13.2.0
 
-  '@hot-labs/omni-sdk@2.14.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
+  '@hot-labs/omni-sdk@2.16.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/anchor': 0.29.0(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@near-js/crypto': 2.2.3(@near-js/types@2.2.3)(@near-js/utils@2.2.3(@near-js/types@2.2.3))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring separate Horizon and Soroban server URLs for Stellar network connections, allowing dual server configuration.
* **Bug Fixes**
  * Improved error handling to ensure all required Stellar RPC endpoints are provided.
* **Chores**
  * Updated dependency to @hot-labs/omni-sdk version 2.16.0.
* **Tests**
  * Expanded test coverage for Stellar RPC URL configuration and error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->