### PR TITLE
fix(bridge-sdk): allow specifying only horizon or sorban server

### DIFF
--- a/packages/bridge-sdk/src/lib/configure-rpc-config.test.ts
+++ b/packages/bridge-sdk/src/lib/configure-rpc-config.test.ts
@@ -173,13 +173,12 @@ describe("configureStellarRpcUrls()", () => {
 	it("overrides default RPC URLs", () => {
 		const result = configureStellarRpcUrls(mockDefaultRpcUrls, {
 			[Chains.Stellar]: {
-				soroban: ["https://customsorobanrpc.com"],
 				horizon: ["https://customhorizonrpc.com"],
 			},
 		});
 
 		expect(result).toEqual({
-			soroban: ["https://customsorobanrpc.com"],
+			soroban: ["https://sorobanrpc.com"],
 			horizon: ["https://customhorizonrpc.com"],
 		});
 	});

--- a/packages/bridge-sdk/src/lib/configure-rpc-config.ts
+++ b/packages/bridge-sdk/src/lib/configure-rpc-config.ts
@@ -1,11 +1,11 @@
 import { assert } from "@defuse-protocol/internal-utils";
-import type { RPCEndpointMap } from "../shared-types";
+import type { PartialRPCEndpointMap, RPCEndpointMap } from "../shared-types";
 import { Chains, getEIP155ChainId } from "./caip2";
 import { pick } from "./object";
 
 export function configureEvmRpcUrls(
 	defaultRpcUrls: Record<string, string[]>,
-	userRpcUrls: Partial<RPCEndpointMap> | undefined,
+	userRpcUrls: PartialRPCEndpointMap | undefined,
 	supportedChains: string[],
 ): Record<number, string[]> {
 	const evmRpcUrls: Record<number, string[]> = Object.fromEntries(
@@ -27,7 +27,7 @@ export function configureEvmRpcUrls(
 
 export function configureStellarRpcUrls(
 	defaultRpcUrls: RPCEndpointMap[typeof Chains.Stellar],
-	userRpcUrls: Partial<RPCEndpointMap> | undefined,
+	userRpcUrls: PartialRPCEndpointMap | undefined,
 ) {
 	const stellarRpcUrls = Object.assign(
 		{},

--- a/packages/bridge-sdk/src/sdk.ts
+++ b/packages/bridge-sdk/src/sdk.ts
@@ -45,7 +45,7 @@ import type {
 	IBridgeSDK,
 	NearTxInfo,
 	ParsedAssetInfo,
-	RPCEndpointMap,
+	PartialRPCEndpointMap,
 	RouteConfig,
 	TxInfo,
 	TxNoInfo,
@@ -55,7 +55,7 @@ import type {
 export interface BridgeSDKConfig {
 	env?: NearIntentsEnv;
 	intentSigner?: IIntentSigner;
-	rpc?: Partial<RPCEndpointMap>;
+	rpc?: PartialRPCEndpointMap;
 	referral: string;
 }
 

--- a/packages/bridge-sdk/src/shared-types.ts
+++ b/packages/bridge-sdk/src/shared-types.ts
@@ -207,3 +207,16 @@ export type RPCEndpointMap = Record<
 		horizon: string[];
 	};
 };
+
+type DeepPartial<T> = T extends object
+	? T extends Array<infer U>
+		? Array<DeepPartial<U>>
+		: // biome-ignore lint/complexity/noBannedTypes: <explanation>
+			T extends Function
+			? T
+			: {
+					[P in keyof T]?: DeepPartial<T[P]>;
+				}
+	: T;
+
+export type PartialRPCEndpointMap = DeepPartial<RPCEndpointMap>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal type definitions to improve flexibility for RPC endpoint configuration.
  * Enhanced type annotations for configuration options without impacting user-facing functionality.
* **Tests**
  * Adjusted test cases to align with updated configuration type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->