### PR TITLE
chore: switch to new Aurora RPC endpoint

### DIFF
--- a/.changeset/olive-poems-search.md
+++ b/.changeset/olive-poems-search.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/internal-utils": patch
+---
+
+Switch Aurora RPC endpoint to new URL for proper load balancing and multi-region failover.

--- a/packages/internal-utils/src/nearClient.ts
+++ b/packages/internal-utils/src/nearClient.ts
@@ -5,7 +5,7 @@ import { nearFailoverRpcProvider } from "./utils/failover";
  * https://docs.near.org/api/rpc/providers
  */
 export const PUBLIC_NEAR_RPC_URLS = [
-	"https://nearrpc.aurora.dev",
+	"https://relmn.aurora.dev",
 	"https://free.rpc.fastnear.com",
 	"https://rpc.mainnet.near.org",
 ];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the default NEAR RPC provider to a new Aurora endpoint to improve reliability through better load balancing and multi‑region failover. No API changes expected.
- **Chores**
  - Added a changeset to release a patch for @defuse-protocol/internal-utils.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->