### PR TITLE
feat: omni withdraw to specific chain

### DIFF
--- a/.changeset/weak-pumas-float.md
+++ b/.changeset/weak-pumas-float.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Add withdrawal to specific chain via omni bridge

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts
@@ -269,7 +269,8 @@ export class HotBridge implements Bridge {
 				if (typeof status === "string") {
 					return {
 						hash:
-							"chain" in args.routeConfig
+							"chain" in args.routeConfig &&
+							args.routeConfig.chain !== undefined
 								? formatTxHash(status, args.routeConfig.chain)
 								: status,
 					};

--- a/packages/intents-sdk/src/bridges/omni-bridge/error.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/error.ts
@@ -62,3 +62,15 @@ export class TokenNotFoundInDestinationChainError extends BaseError {
 		);
 	}
 }
+
+export type UnsupportedChainErrorType = UnsupportedChainError & {
+	name: "UnsupportedOmniNetworkError";
+};
+export class UnsupportedChainError extends BaseError {
+	constructor(chainKind: Chain) {
+		super(`Chain is not supported by the omni bridge ${chainKind}`, {
+			metaMessages: [`Chain: ${chainKind}`],
+			name: "UnsupportedChain",
+		});
+	}
+}

--- a/packages/intents-sdk/src/bridges/omni-bridge/error.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/error.ts
@@ -1,4 +1,5 @@
 import { BaseError } from "@defuse-protocol/internal-utils";
+import type { Chain } from "../../lib/caip2";
 
 export type OmniTransferNotFoundErrorType = OmniTransferNotFoundError & {
 	name: "OmniTransferNotFoundError";
@@ -41,5 +42,23 @@ export class TokenNotSupportedByOmniRelayerError extends BaseError {
 			metaMessages: [`Token: ${token}`],
 			name: "TokenNotSupportedByOmniRelayerError",
 		});
+	}
+}
+export type TokenNotFoundOnDestinationNetworkErrorType =
+	TokenNotFoundOnDestinationNetworkError & {
+		name: "TokenNotFoundOnDestinationNetworkError";
+	};
+export class TokenNotFoundOnDestinationNetworkError extends BaseError {
+	constructor(
+		public token: string,
+		chainKind: Chain,
+	) {
+		super(
+			`The token ${token} doesn't exist on destination network ${chainKind}`,
+			{
+				metaMessages: [`Token: ${token}`, `Destination Chain: ${chainKind}`],
+				name: "TokenNotFoundOnDestinationNetworkError",
+			},
+		);
 	}
 }

--- a/packages/intents-sdk/src/bridges/omni-bridge/error.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/error.ts
@@ -44,20 +44,20 @@ export class TokenNotSupportedByOmniRelayerError extends BaseError {
 		});
 	}
 }
-export type TokenNotFoundOnDestinationChainErrorType =
-	TokenNotFoundOnDestinationChainError & {
-		name: "TokenNotFoundOnDestinationChainError";
+export type TokenNotFoundInDestinationChainErrorType =
+	TokenNotFoundInDestinationChainError & {
+		name: "TokenNotFoundInDestinationChainError";
 	};
-export class TokenNotFoundOnDestinationChainError extends BaseError {
+export class TokenNotFoundInDestinationChainError extends BaseError {
 	constructor(
 		public token: string,
 		chainKind: Chain,
 	) {
 		super(
-			`The token ${token} doesn't exist on destination network ${chainKind}`,
+			`The token ${token} doesn't exist in destination network ${chainKind}`,
 			{
 				metaMessages: [`Token: ${token}`, `Destination Chain: ${chainKind}`],
-				name: "TokenNotFoundOnDestinationChainError",
+				name: "TokenNotFoundInDestinationChainError",
 			},
 		);
 	}

--- a/packages/intents-sdk/src/bridges/omni-bridge/error.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/error.ts
@@ -62,15 +62,3 @@ export class TokenNotFoundInDestinationChainError extends BaseError {
 		);
 	}
 }
-
-export type UnsupportedChainErrorType = UnsupportedChainError & {
-	name: "UnsupportedOmniNetworkError";
-};
-export class UnsupportedChainError extends BaseError {
-	constructor(chainKind: Chain) {
-		super(`Chain is not supported by the omni bridge ${chainKind}`, {
-			metaMessages: [`Chain: ${chainKind}`],
-			name: "UnsupportedChain",
-		});
-	}
-}

--- a/packages/intents-sdk/src/bridges/omni-bridge/error.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/error.ts
@@ -44,11 +44,11 @@ export class TokenNotSupportedByOmniRelayerError extends BaseError {
 		});
 	}
 }
-export type TokenNotFoundOnDestinationNetworkErrorType =
-	TokenNotFoundOnDestinationNetworkError & {
-		name: "TokenNotFoundOnDestinationNetworkError";
+export type TokenNotFoundOnDestinationChainErrorType =
+	TokenNotFoundOnDestinationChainError & {
+		name: "TokenNotFoundOnDestinationChainError";
 	};
-export class TokenNotFoundOnDestinationNetworkError extends BaseError {
+export class TokenNotFoundOnDestinationChainError extends BaseError {
 	constructor(
 		public token: string,
 		chainKind: Chain,
@@ -57,7 +57,7 @@ export class TokenNotFoundOnDestinationNetworkError extends BaseError {
 			`The token ${token} doesn't exist on destination network ${chainKind}`,
 			{
 				metaMessages: [`Token: ${token}`, `Destination Chain: ${chainKind}`],
-				name: "TokenNotFoundOnDestinationNetworkError",
+				name: "TokenNotFoundOnDestinationChainError",
 			},
 		);
 	}

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
@@ -3,6 +3,7 @@ import { ChainKind, omniAddress } from "omni-bridge-sdk";
 import type { IntentPrimitive } from "../../intents/shared-types";
 import { Chains } from "../../lib/caip2";
 import type { Chain } from "../../lib/caip2";
+import { UnsupportedChainError } from "./error";
 import { OMNI_BRIDGE_CONTRACT } from "./omni-bridge-constants";
 
 export function createWithdrawIntentPrimitive(params: {
@@ -33,6 +34,15 @@ export function createWithdrawIntentPrimitive(params: {
 			native_token_fee: "0",
 		}),
 	};
+}
+
+
+export function targetChainSupportedByOmniBridge(network: Chain) {
+	try {
+		return Boolean(caip2ToChainKind(network));
+	} catch {
+		throw new UnsupportedChainError(network);
+	}
 }
 
 export function caip2ToChainKind(network: Chain): ChainKind {

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
@@ -3,7 +3,6 @@ import { ChainKind, omniAddress } from "omni-bridge-sdk";
 import type { IntentPrimitive } from "../../intents/shared-types";
 import { Chains } from "../../lib/caip2";
 import type { Chain } from "../../lib/caip2";
-import { UnsupportedChainError } from "./error";
 import { OMNI_BRIDGE_CONTRACT } from "./omni-bridge-constants";
 
 export function createWithdrawIntentPrimitive(params: {
@@ -36,11 +35,20 @@ export function createWithdrawIntentPrimitive(params: {
 	};
 }
 
-export function targetChainSupportedByOmniBridge(network: Chain) {
-	try {
-		return Boolean(caip2ToChainKind(network));
-	} catch {
-		throw new UnsupportedChainError(network);
+export function targetChainSupportedByOmniBridge(network: Chain): boolean {
+	switch (network) {
+		case Chains.Ethereum:
+			return true;
+		case Chains.Base:
+			return true;
+		case Chains.Arbitrum:
+			return true;
+		case Chains.Solana:
+			return true;
+		case Chains.Bitcoin:
+			return true;
+		default:
+			return false;
 	}
 }
 

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
@@ -36,7 +36,6 @@ export function createWithdrawIntentPrimitive(params: {
 	};
 }
 
-
 export function targetChainSupportedByOmniBridge(network: Chain) {
 	try {
 		return Boolean(caip2ToChainKind(network));

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -52,6 +52,7 @@ import {
 	caip2ToChainKind,
 	chainKindToCaip2,
 	createWithdrawIntentPrimitive,
+	targetChainSupportedByOmniBridge,
 } from "./omni-bridge-utils";
 
 type MinStorageBalance = bigint;
@@ -91,7 +92,9 @@ export class OmniBridge implements Bridge {
 
 	supports(params: Pick<WithdrawalParams, "assetId" | "routeConfig">): boolean {
 		try {
-			if (this.targetChainSpecified(params.routeConfig)) return true;
+			if (this.targetChainSpecified(params.routeConfig)) {
+				return targetChainSupportedByOmniBridge(params.routeConfig.chain);
+			}
 			return this.parseAssetId(params.assetId) !== null;
 		} catch {
 			return false;
@@ -100,11 +103,11 @@ export class OmniBridge implements Bridge {
 
 	targetChainSpecified(
 		routeConfig?: RouteConfig,
-	): routeConfig is OmniBridgeRouteConfig {
+	): routeConfig is OmniBridgeRouteConfig & { chain: Chain } {
 		return Boolean(
 			routeConfig?.route &&
-			routeConfig.route === RouteEnum.OmniBridge &&
-			routeConfig.chain,
+				routeConfig.route === RouteEnum.OmniBridge &&
+				routeConfig.chain,
 		);
 	}
 

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -41,7 +41,7 @@ import type {
 import {
 	OmniTransferDestinationChainHashNotFoundError,
 	OmniTransferNotFoundError,
-	TokenNotFoundOnDestinationChainError,
+	TokenNotFoundInDestinationChainError,
 	TokenNotSupportedByOmniRelayerError,
 } from "./error";
 import {
@@ -103,8 +103,8 @@ export class OmniBridge implements Bridge {
 	): routeConfig is OmniBridgeRouteConfig {
 		return Boolean(
 			routeConfig?.route &&
-				routeConfig.route === RouteEnum.OmniBridge &&
-				routeConfig.chain,
+			routeConfig.route === RouteEnum.OmniBridge &&
+			routeConfig.chain,
 		);
 	}
 
@@ -130,7 +130,7 @@ export class OmniBridge implements Bridge {
 					routeConfig.chain,
 				);
 			if (tokenOnDestinationNetwork === null) {
-				throw new TokenNotFoundOnDestinationChainError(
+				throw new TokenNotFoundInDestinationChainError(
 					assetId,
 					routeConfig.chain,
 				);

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -41,7 +41,7 @@ import type {
 import {
 	OmniTransferDestinationChainHashNotFoundError,
 	OmniTransferNotFoundError,
-	TokenNotFoundOnDestinationNetworkError,
+	TokenNotFoundOnDestinationChainError,
 	TokenNotSupportedByOmniRelayerError,
 } from "./error";
 import {
@@ -130,7 +130,7 @@ export class OmniBridge implements Bridge {
 					routeConfig.chain,
 				);
 			if (tokenOnDestinationNetwork === null) {
-				throw new TokenNotFoundOnDestinationNetworkError(
+				throw new TokenNotFoundOnDestinationChainError(
 					assetId,
 					routeConfig.chain,
 				);

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -155,6 +155,7 @@ export class IntentsSDK implements IIntentsSDK {
 					amount: actualAmount,
 					destinationAddress: args.withdrawalParams.destinationAddress,
 					feeEstimation: args.feeEstimation,
+					routeConfig: args.withdrawalParams.routeConfig,
 					logger: args.logger,
 				});
 

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -192,6 +192,7 @@ export type HotBridgeRouteConfig = {
 
 export type OmniBridgeRouteConfig = {
 	route: RouteEnum["OmniBridge"];
+	chain: Chain;
 };
 
 export type RouteConfig =
@@ -225,6 +226,7 @@ export interface Bridge {
 		amount: bigint;
 		destinationAddress: string;
 		feeEstimation: FeeEstimation;
+		routeConfig?: RouteConfig;
 		logger?: ILogger;
 	}): Promise<void>;
 

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -192,7 +192,7 @@ export type HotBridgeRouteConfig = {
 
 export type OmniBridgeRouteConfig = {
 	route: RouteEnum["OmniBridge"];
-	chain: Chain;
+	chain?: Chain;
 };
 
 export type RouteConfig =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Route-aware OmniBridge: optional routeConfig can target a specific chain, affecting asset detection, validation, fee estimates, and withdrawal intents.
  - Explicit errors for unsupported destination chains or missing destination tokens.

- **Public API**
  - Withdrawal flows now accept an optional routeConfig so callers can specify route/chain preferences for route-aware behavior.

- **Performance**
  - Cached destination-token lookups to reduce latency and repeated resolution calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->