### PR TITLE
feat: add SEP-0053 standard support for Stellar wallets

### DIFF
--- a/.changeset/strong-toes-learn.md
+++ b/.changeset/strong-toes-learn.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/internal-utils": minor
+---
+
+Add SEP-0053 standard support for Stellar wallet signatures.

--- a/packages/internal-utils/src/types/walletMessage.ts
+++ b/packages/internal-utils/src/types/walletMessage.ts
@@ -55,7 +55,7 @@ export type StellarMessage = {
 };
 
 export type StellarSignatureData = {
-	type: "STELLAR";
+	type: "STELLAR_RAW" | "STELLAR_SEP53";
 	signatureData: Uint8Array;
 	signedData: StellarMessage;
 };

--- a/packages/internal-utils/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
+++ b/packages/internal-utils/src/utils/__snapshots__/prepareBroadcastRequest.test.ts.snap
@@ -23,6 +23,15 @@ exports[`prepareSwapSignedData() > should return the correct signed data for a S
 }
 `;
 
+exports[`prepareSwapSignedData() > should return the correct signed data for a Stellar SEP-0053 signature 1`] = `
+{
+  "payload": "{"foo":"bar"}",
+  "public_key": "ed25519:HRP7jA5tkMvCaNzPnu9cbNuAF1rJuwC2nBkFQtFpSQHC",
+  "signature": "ed25519:S88bG8B",
+  "standard": "sep53",
+}
+`;
+
 exports[`prepareSwapSignedData() > should return the correct signed data for a Stellar signature 1`] = `
 {
   "payload": "{"foo":"bar"}",

--- a/packages/internal-utils/src/utils/prepareBroadcastRequest.test.ts
+++ b/packages/internal-utils/src/utils/prepareBroadcastRequest.test.ts
@@ -99,7 +99,24 @@ describe("prepareSwapSignedData()", () => {
 
 	it("should return the correct signed data for a Stellar signature", () => {
 		const signature: StellarSignatureData = {
-			type: "STELLAR",
+			type: "STELLAR_RAW",
+			signatureData: Buffer.from("deadbeef1c", "hex"),
+			signedData: {
+				message: JSON.stringify({ foo: "bar" }),
+			},
+		};
+
+		expect(
+			prepareSwapSignedData(signature, {
+				userAddress: "GDZ7T36V5BBWLZTM7NGZYWJYRIYBFXFVYQT3EOGO7G4JCEO6DBYL7DC2",
+				userChainType: "stellar",
+			}),
+		).toMatchSnapshot();
+	});
+
+	it("should return the correct signed data for a Stellar SEP-0053 signature", () => {
+		const signature: StellarSignatureData = {
+			type: "STELLAR_SEP53",
 			signatureData: Buffer.from("deadbeef1c", "hex"),
 			signedData: {
 				message: JSON.stringify({ foo: "bar" }),

--- a/packages/internal-utils/src/utils/prepareBroadcastRequest.ts
+++ b/packages/internal-utils/src/utils/prepareBroadcastRequest.ts
@@ -66,13 +66,29 @@ export function prepareSwapSignedData(
 			};
 		}
 
-		case "STELLAR": {
+		case "STELLAR_RAW": {
 			assert(
 				userInfo.userChainType === "stellar",
 				"User chain and signature chain must match",
 			);
 			return {
 				standard: "raw_ed25519",
+				payload: signature.signedData.message,
+				// We should encode the Stellar address to base58
+				public_key: `ed25519:${base58.encode(
+					stellarAddressToBytes(userInfo.userAddress),
+				)}`,
+				signature: transformED25519Signature(signature.signatureData),
+			};
+		}
+
+		case "STELLAR_SEP53": {
+			assert(
+				userInfo.userChainType === "stellar",
+				"User chain and signature chain must match",
+			);
+			return {
+				standard: "sep53",
 				payload: signature.signedData.message,
 				// We should encode the Stellar address to base58
 				public_key: `ed25519:${base58.encode(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Stellar SEP-0053 wallet signatures alongside existing raw signatures, enabling signing and broadcast from compatible wallets.
- Tests
  - Expanded coverage to include both raw and SEP-0053 Stellar signature variants.
- Chores
  - Bumped internal utilities package to a minor version and updated the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->