### PR TITLE
feat: check if assetId passes bridge asset validation logic

### DIFF
--- a/.changeset/twenty-candles-cover.md
+++ b/.changeset/twenty-candles-cover.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Add stricter validation of `assetId`. Add new `UnsupportedAssetIdError` error.

--- a/packages/intents-sdk/index.ts
+++ b/packages/intents-sdk/index.ts
@@ -97,6 +97,8 @@ export {
 	type TrustlineNotFoundErrorType,
 	UnsupportedDestinationMemoError,
 	type UnsupportedDestinationMemoErrorType,
+	UnsupportedAssetIdError,
+	type UnsupportedAssetIdErrorType,
 } from "./src/classes/errors";
 
 // Hot Bridge Errors

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
@@ -36,7 +36,7 @@ describe("AuroraEngineBridge", () => {
 				nearProvider: {} as any,
 			});
 
-			await expect(() => bridge.supports({ assetId })).rejects.toThrow(
+			await expect(bridge.supports({ assetId })).rejects.toThrow(
 				UnsupportedAssetIdError,
 			);
 

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { UnsupportedAssetIdError } from "../../classes/errors";
+import { createVirtualChainRoute } from "../../lib/route-config-factory";
+import { AuroraEngineBridge } from "./aurora-engine-bridge";
+
+describe("AuroraEngineBridge", () => {
+	it.each([
+		"nep141:btc.omft.near",
+		"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+	])("supports %s", async (tokenId) => {
+		const bridge = new AuroraEngineBridge({
+			env: "production",
+			nearProvider: {} as any,
+		});
+
+		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+	});
+
+	it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
+		"does not support %s",
+		async (tokenId) => {
+			const bridge = new AuroraEngineBridge({
+				env: "production",
+				nearProvider: {} as any,
+			});
+
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
+		},
+	);
+
+	it.each(["invalid_string"])(
+		"throws UnsupportedAssetIdError if invalid %s",
+		async (assetId) => {
+			const bridge = new AuroraEngineBridge({
+				env: "production",
+				nearProvider: {} as any,
+			});
+
+			await expect(() => bridge.supports({ assetId })).rejects.toThrow(
+				UnsupportedAssetIdError,
+			);
+
+			// It throws even if routeConfig is provided.
+			await expect(() =>
+				bridge.supports({
+					assetId,
+					routeConfig: createVirtualChainRoute("", null),
+				}),
+			).rejects.toThrow(UnsupportedAssetIdError);
+		},
+	);
+
+	it("throws UnsupportedAssetIdError if routeConfig specified but assetId is not NEP-141 token", async () => {
+		const bridge = new AuroraEngineBridge({
+			env: "production",
+			nearProvider: {} as any,
+		});
+
+		await expect(() =>
+			bridge.supports({
+				assetId: "nep245:wrap.near:foo",
+				routeConfig: createVirtualChainRoute("", null),
+			}),
+		).rejects.toThrow(UnsupportedAssetIdError);
+	});
+});

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
@@ -4,63 +4,60 @@ import { createVirtualChainRoute } from "../../lib/route-config-factory";
 import { AuroraEngineBridge } from "./aurora-engine-bridge";
 
 describe("AuroraEngineBridge", () => {
-	it.each([
-		"nep141:btc.omft.near",
-		"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
-	])("supports %s", async (tokenId) => {
-		const bridge = new AuroraEngineBridge({
-			env: "production",
-			nearProvider: {} as any,
-		});
-
-		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
-	});
-
-	it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
-		"does not support %s",
-		async (tokenId) => {
+	describe("supports()", () => {
+		it.each([
+			"nep141:btc.omft.near",
+			"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+			"nep141:wrap.near",
+		])("supports NEP-141 if routeConfig passed", async (tokenId) => {
 			const bridge = new AuroraEngineBridge({
 				env: "production",
 				nearProvider: {} as any,
 			});
 
-			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
-		},
-	);
-
-	it.each(["invalid_string"])(
-		"throws UnsupportedAssetIdError if invalid %s",
-		async (assetId) => {
-			const bridge = new AuroraEngineBridge({
-				env: "production",
-				nearProvider: {} as any,
-			});
-
-			await expect(bridge.supports({ assetId })).rejects.toThrow(
-				UnsupportedAssetIdError,
-			);
-
-			// It throws even if routeConfig is provided.
-			await expect(() =>
+			await expect(
 				bridge.supports({
-					assetId,
+					assetId: tokenId,
 					routeConfig: createVirtualChainRoute("", null),
 				}),
-			).rejects.toThrow(UnsupportedAssetIdError);
-		},
-	);
-
-	it("throws UnsupportedAssetIdError if routeConfig specified but assetId is not NEP-141 token", async () => {
-		const bridge = new AuroraEngineBridge({
-			env: "production",
-			nearProvider: {} as any,
+			).resolves.toBe(true);
 		});
 
-		await expect(() =>
-			bridge.supports({
-				assetId: "nep245:wrap.near:foo",
-				routeConfig: createVirtualChainRoute("", null),
-			}),
-		).rejects.toThrow(UnsupportedAssetIdError);
+		it.each([
+			"nep141:btc.omft.near",
+			"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		])("doesn't support any if routeConfig not passed", async (tokenId) => {
+			const bridge = new AuroraEngineBridge({
+				env: "production",
+				nearProvider: {} as any,
+			});
+
+			await expect(
+				bridge.supports({
+					assetId: tokenId,
+				}),
+			).resolves.toBe(false);
+		});
+
+		it.each([
+			"invalid_string",
+			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		])(
+			"throws UnsupportedAssetIdError if routeConfig passed, but assetId is not NEP-141 token",
+			async (assetId) => {
+				const bridge = new AuroraEngineBridge({
+					env: "production",
+					nearProvider: {} as any,
+				});
+
+				await expect(
+					bridge.supports({
+						assetId: assetId,
+						routeConfig: createVirtualChainRoute("", null),
+					}),
+				).rejects.toThrow(UnsupportedAssetIdError);
+			},
+		);
 	});
 });

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
@@ -46,14 +46,14 @@ export class AuroraEngineBridge implements Bridge {
 	async supports(
 		params: Pick<WithdrawalParams, "assetId" | "routeConfig">,
 	): Promise<boolean> {
-		if (params.routeConfig != null && !this.is(params.routeConfig)) {
+		if (params.routeConfig == null || !this.is(params.routeConfig)) {
 			return false;
 		}
 
 		const assetInfo = parseDefuseAssetId(params.assetId);
 		const isValid = assetInfo.standard === "nep141";
 
-		if (params.routeConfig != null) {
+		if (!isValid) {
 			throw new UnsupportedAssetIdError(
 				params.assetId,
 				"`assetId` does not match `routeConfig`.",

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
@@ -36,7 +36,7 @@ describe("DirectBridge", () => {
 				nearProvider: {} as any,
 			});
 
-			await expect(() => bridge.supports({ assetId })).rejects.toThrow(
+			await expect(bridge.supports({ assetId })).rejects.toThrow(
 				UnsupportedAssetIdError,
 			);
 

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
@@ -4,63 +4,57 @@ import { createNearWithdrawalRoute } from "../../lib/route-config-factory";
 import { DirectBridge } from "./direct-bridge";
 
 describe("DirectBridge", () => {
-	it.each([
-		"nep141:btc.omft.near",
-		"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
-	])("supports %s", async (tokenId) => {
-		const bridge = new DirectBridge({
-			env: "production",
-			nearProvider: {} as any,
-		});
-
-		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
-	});
-
-	it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
-		"does not support %s",
-		async (tokenId) => {
+	describe("supports()", () => {
+		it.each([
+			"nep141:btc.omft.near",
+			"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+		])("supports NEP-141 even if routeConfig not passed", async (tokenId) => {
 			const bridge = new DirectBridge({
 				env: "production",
 				nearProvider: {} as any,
 			});
 
-			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
-		},
-	);
-
-	it.each(["invalid_string"])(
-		"throws UnsupportedAssetIdError if invalid %s",
-		async (assetId) => {
-			const bridge = new DirectBridge({
-				env: "production",
-				nearProvider: {} as any,
-			});
-
-			await expect(bridge.supports({ assetId })).rejects.toThrow(
-				UnsupportedAssetIdError,
-			);
-
-			// It throws even if routeConfig is provided.
-			await expect(() =>
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+			await expect(
 				bridge.supports({
-					assetId,
+					assetId: tokenId,
 					routeConfig: createNearWithdrawalRoute(),
 				}),
-			).rejects.toThrow(UnsupportedAssetIdError);
-		},
-	);
-
-	it("throws UnsupportedAssetIdError if routeConfig specified but assetId is not NEP-141 token", async () => {
-		const bridge = new DirectBridge({
-			env: "production",
-			nearProvider: {} as any,
+			).resolves.toBe(true);
 		});
 
-		await expect(() =>
-			bridge.supports({
-				assetId: "nep245:wrap.near:foo",
-				routeConfig: createNearWithdrawalRoute(),
-			}),
-		).rejects.toThrow(UnsupportedAssetIdError);
+		it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
+			"doesn't support NEP-245",
+			async (tokenId) => {
+				const bridge = new DirectBridge({
+					env: "production",
+					nearProvider: {} as any,
+				});
+
+				await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(
+					false,
+				);
+			},
+		);
+
+		it.each([
+			"invalid_string",
+			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		])(
+			"throws UnsupportedAssetIdError if routeConfig passed, but assetId is not NEP-141",
+			async (assetId) => {
+				const bridge = new DirectBridge({
+					env: "production",
+					nearProvider: {} as any,
+				});
+
+				await expect(
+					bridge.supports({
+						assetId,
+						routeConfig: createNearWithdrawalRoute(),
+					}),
+				).rejects.toThrow(UnsupportedAssetIdError);
+			},
+		);
 	});
 });

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { UnsupportedAssetIdError } from "../../classes/errors";
+import { createNearWithdrawalRoute } from "../../lib/route-config-factory";
+import { DirectBridge } from "./direct-bridge";
+
+describe("DirectBridge", () => {
+	it.each([
+		"nep141:btc.omft.near",
+		"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+	])("supports %s", async (tokenId) => {
+		const bridge = new DirectBridge({
+			env: "production",
+			nearProvider: {} as any,
+		});
+
+		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+	});
+
+	it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
+		"does not support %s",
+		async (tokenId) => {
+			const bridge = new DirectBridge({
+				env: "production",
+				nearProvider: {} as any,
+			});
+
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
+		},
+	);
+
+	it.each(["invalid_string"])(
+		"throws UnsupportedAssetIdError if invalid %s",
+		async (assetId) => {
+			const bridge = new DirectBridge({
+				env: "production",
+				nearProvider: {} as any,
+			});
+
+			await expect(() => bridge.supports({ assetId })).rejects.toThrow(
+				UnsupportedAssetIdError,
+			);
+
+			// It throws even if routeConfig is provided.
+			await expect(() =>
+				bridge.supports({
+					assetId,
+					routeConfig: createNearWithdrawalRoute(),
+				}),
+			).rejects.toThrow(UnsupportedAssetIdError);
+		},
+	);
+
+	it("throws UnsupportedAssetIdError if routeConfig specified but assetId is not NEP-141 token", async () => {
+		const bridge = new DirectBridge({
+			env: "production",
+			nearProvider: {} as any,
+		});
+
+		await expect(() =>
+			bridge.supports({
+				assetId: "nep245:wrap.near:foo",
+				routeConfig: createNearWithdrawalRoute(),
+			}),
+		).rejects.toThrow(UnsupportedAssetIdError);
+	});
+});

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { HotBridge } from "./hot-bridge";
+import { UnsupportedAssetIdError } from "../../classes/errors";
+import hotOmniSdk from "@hot-labs/omni-sdk";
+import { createHotBridgeRoute } from "../../lib/route-config-factory";
+import { Chains } from "../../lib/caip2";
+
+describe("HotBridge", () => {
+	it.each([
+		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		// todo: add more test cases for each supported chain
+	])("supports %s", async (tokenId) => {
+		const bridge = new HotBridge({
+			env: "production",
+			hotSdk: new hotOmniSdk.HotBridge({
+				async executeNearTransaction() {
+					throw new Error("not implemented");
+				},
+			}),
+		});
+
+		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+	});
+
+	it.each(["nep141:btc.omft.near"])("does not support %s", async (tokenId) => {
+		const bridge = new HotBridge({
+			env: "production",
+			hotSdk: new hotOmniSdk.HotBridge({
+				async executeNearTransaction() {
+					throw new Error("not implemented");
+				},
+			}),
+		});
+		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
+	});
+
+	it.each([
+		"invalid_string",
+		"nep141:v2_1.omni.hot.tg:56_11111111111111111111",
+		"nep245:v2_1.omni.hot.tg",
+		"nep245:v2_1.omni.hot.tg:FOOBAR",
+	])("throws UnsupportedAssetIdError if invalid %s", async (assetId) => {
+		const bridge = new HotBridge({
+			env: "production",
+			hotSdk: new hotOmniSdk.HotBridge({
+				async executeNearTransaction() {
+					throw new Error("not implemented");
+				},
+			}),
+		});
+
+		await expect(() => bridge.supports({ assetId: assetId })).rejects.toThrow(
+			UnsupportedAssetIdError,
+		);
+
+		// It throws even if routeConfig is provided.
+		await expect(() =>
+			bridge.supports({
+				assetId: assetId,
+				routeConfig: createHotBridgeRoute(Chains.TON),
+			}),
+		).rejects.toThrow(UnsupportedAssetIdError);
+	});
+
+	it("throws UnsupportedAssetIdError if routeConfig specified but assetId is not HOT token", async () => {
+		const bridge = new HotBridge({
+			env: "production",
+			hotSdk: new hotOmniSdk.HotBridge({
+				async executeNearTransaction() {
+					throw new Error("not implemented");
+				},
+			}),
+		});
+
+		await expect(() =>
+			bridge.supports({
+				assetId: "nep141:wrap.near",
+				routeConfig: createHotBridgeRoute(Chains.TON),
+			}),
+		).rejects.toThrow(UnsupportedAssetIdError);
+	});
+});

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
@@ -6,77 +6,93 @@ import { createHotBridgeRoute } from "../../lib/route-config-factory";
 import { Chains } from "../../lib/caip2";
 
 describe("HotBridge", () => {
-	it.each([
-		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
-		// todo: add more test cases for each supported chain
-	])("supports %s", async (tokenId) => {
-		const bridge = new HotBridge({
-			env: "production",
-			hotSdk: new hotOmniSdk.HotBridge({
-				async executeNearTransaction() {
-					throw new Error("not implemented");
-				},
-			}),
+	describe("supports()", () => {
+		it.each([
+			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+			// todo: add more test cases for each supported chain
+		])("supports `v2_1.omni.hot.tg` tokens", async (tokenId) => {
+			const bridge = new HotBridge({
+				env: "production",
+				hotSdk: new hotOmniSdk.HotBridge({
+					async executeNearTransaction() {
+						throw new Error("not implemented");
+					},
+				}),
+			});
+
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+			await expect(
+				bridge.supports({
+					assetId: tokenId,
+					routeConfig: createHotBridgeRoute(Chains.TON),
+				}),
+			).resolves.toBe(true);
 		});
 
-		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
-	});
-
-	it.each(["nep141:btc.omft.near"])("does not support %s", async (tokenId) => {
-		const bridge = new HotBridge({
-			env: "production",
-			hotSdk: new hotOmniSdk.HotBridge({
-				async executeNearTransaction() {
-					throw new Error("not implemented");
-				},
-			}),
-		});
-		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
-	});
-
-	it.each([
-		"invalid_string",
-		"nep141:v2_1.omni.hot.tg:56_11111111111111111111",
-		"nep245:v2_1.omni.hot.tg",
-		"nep245:v2_1.omni.hot.tg:FOOBAR",
-	])("throws UnsupportedAssetIdError if invalid %s", async (assetId) => {
-		const bridge = new HotBridge({
-			env: "production",
-			hotSdk: new hotOmniSdk.HotBridge({
-				async executeNearTransaction() {
-					throw new Error("not implemented");
-				},
-			}),
+		it.each([
+			"nep141:btc.omft.near",
+			"nep245:v3_1.omni.hot.tg:56_11111111111111111111",
+		])("doesn't support `v2_1.omni.hot.tg` tokens", async (tokenId) => {
+			const bridge = new HotBridge({
+				env: "production",
+				hotSdk: new hotOmniSdk.HotBridge({
+					async executeNearTransaction() {
+						throw new Error("not implemented");
+					},
+				}),
+			});
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
 		});
 
-		await expect(bridge.supports({ assetId: assetId })).rejects.toThrow(
-			UnsupportedAssetIdError,
+		it.each([
+			"nep141:v2_1.omni.hot.tg:56_11111111111111111111",
+			"nep245:v2_1.omni.hot.tg",
+			"nep245:v2_1.omni.hot.tg:FOOBAR",
+		])(
+			"throws UnsupportedAssetIdError if misspelled HOT token",
+			async (assetId) => {
+				const bridge = new HotBridge({
+					env: "production",
+					hotSdk: new hotOmniSdk.HotBridge({
+						async executeNearTransaction() {
+							throw new Error("not implemented");
+						},
+					}),
+				});
+
+				await expect(bridge.supports({ assetId: assetId })).rejects.toThrow(
+					UnsupportedAssetIdError,
+				);
+
+				// It throws even if routeConfig is provided.
+				await expect(
+					bridge.supports({
+						assetId: assetId,
+						routeConfig: createHotBridgeRoute(Chains.TON),
+					}),
+				).rejects.toThrow(UnsupportedAssetIdError);
+			},
 		);
 
-		// It throws even if routeConfig is provided.
-		await expect(() =>
-			bridge.supports({
-				assetId: assetId,
-				routeConfig: createHotBridgeRoute(Chains.TON),
-			}),
-		).rejects.toThrow(UnsupportedAssetIdError);
-	});
+		it.each(["invalid_string", "nep141:wrap.near", "nep141:btc.omft.near"])(
+			"throws UnsupportedAssetIdError if routeConfig passed, but assetId is not HOT token",
+			async (assetId) => {
+				const bridge = new HotBridge({
+					env: "production",
+					hotSdk: new hotOmniSdk.HotBridge({
+						async executeNearTransaction() {
+							throw new Error("not implemented");
+						},
+					}),
+				});
 
-	it("throws UnsupportedAssetIdError if routeConfig specified but assetId is not HOT token", async () => {
-		const bridge = new HotBridge({
-			env: "production",
-			hotSdk: new hotOmniSdk.HotBridge({
-				async executeNearTransaction() {
-					throw new Error("not implemented");
-				},
-			}),
-		});
-
-		await expect(() =>
-			bridge.supports({
-				assetId: "nep141:wrap.near",
-				routeConfig: createHotBridgeRoute(Chains.TON),
-			}),
-		).rejects.toThrow(UnsupportedAssetIdError);
+				await expect(
+					bridge.supports({
+						assetId,
+						routeConfig: createHotBridgeRoute(Chains.TON),
+					}),
+				).rejects.toThrow(UnsupportedAssetIdError);
+			},
+		);
 	});
 });

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
@@ -49,7 +49,7 @@ describe("HotBridge", () => {
 			}),
 		});
 
-		await expect(() => bridge.supports({ assetId: assetId })).rejects.toThrow(
+		await expect(bridge.supports({ assetId: assetId })).rejects.toThrow(
 			UnsupportedAssetIdError,
 		);
 

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
@@ -5,66 +5,66 @@ import { createPoaBridgeRoute } from "../../lib/route-config-factory";
 import { Chains } from "../../lib/caip2";
 
 describe("PoaBridge", () => {
-	it.each([
-		"nep141:btc.omft.near",
-		"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
-	])("supports %s", async (tokenId) => {
-		const bridge = new PoaBridge({ env: "production" });
-
-		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
-		await expect(
-			bridge.supports({
-				assetId: tokenId,
-				// For now, we can pass any `chain`. It's not validated.
-				routeConfig: createPoaBridgeRoute(Chains.Bitcoin),
-			}),
-		).resolves.toBe(true);
-	});
-
-	it.each([
-		"nep141:wrap.near",
-		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
-	])("does not support %s", async (tokenId) => {
-		const bridge = new PoaBridge({ env: "production" });
-
-		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
-	});
-
-	it.each([
-		// completely invalid tokenId
-		"invalid_string",
-		// matches POA bridge token pattern, but it is not supported
-		"nep141:unknown.omft.near",
-	])("throws UnsupportedAssetIdError if invalid %s", async (assetId) => {
-		const bridge = new PoaBridge({ env: "production" });
-
-		await expect(bridge.supports({ assetId })).rejects.toThrow(
-			UnsupportedAssetIdError,
-		);
-
-		// It throws even if routeConfig is provided.
-		await expect(() =>
-			bridge.supports({
-				assetId,
-				routeConfig: createPoaBridgeRoute(Chains.Arbitrum),
-			}),
-		).rejects.toThrow(UnsupportedAssetIdError);
-	});
-
-	it.each([
-		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
-		"nep141:wrap.near",
-	])(
-		"throws UnsupportedAssetIdError if routeConfig specified but assetId is not POA token",
-		async (assetId) => {
+	describe("supports()", () => {
+		it.each([
+			"nep141:btc.omft.near",
+			"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+		])("supports `omft.near` tokens", async (tokenId) => {
 			const bridge = new PoaBridge({ env: "production" });
 
-			await expect(() =>
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+			await expect(
 				bridge.supports({
-					assetId,
+					assetId: tokenId,
 					routeConfig: createPoaBridgeRoute(Chains.Bitcoin),
 				}),
-			).rejects.toThrow(UnsupportedAssetIdError);
-		},
-	);
+			).resolves.toBe(true);
+		});
+
+		it.each([
+			"nep141:wrap.near",
+			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		])("doesn't support not `omft.near` tokens", async (tokenId) => {
+			const bridge = new PoaBridge({ env: "production" });
+
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
+		});
+
+		it.each(["nep141:bitcoin.omft.near", "nep141:unknown.omft.near"])(
+			"throws UnsupportedAssetIdError if misspelled POA token",
+			async (assetId) => {
+				const bridge = new PoaBridge({ env: "production" });
+
+				await expect(bridge.supports({ assetId })).rejects.toThrow(
+					UnsupportedAssetIdError,
+				);
+
+				// It throws even if routeConfig is provided.
+				await expect(() =>
+					bridge.supports({
+						assetId,
+						routeConfig: createPoaBridgeRoute(Chains.Arbitrum),
+					}),
+				).rejects.toThrow(UnsupportedAssetIdError);
+			},
+		);
+
+		it.each([
+			"invalid_string",
+			"nep141:wrap.near",
+			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		])(
+			"throws UnsupportedAssetIdError if routeConfig passed, but assetId is not POA token",
+			async (assetId) => {
+				const bridge = new PoaBridge({ env: "production" });
+
+				await expect(() =>
+					bridge.supports({
+						assetId,
+						routeConfig: createPoaBridgeRoute(Chains.Bitcoin),
+					}),
+				).rejects.toThrow(UnsupportedAssetIdError);
+			},
+		);
+	});
 });

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
@@ -21,33 +21,35 @@ describe("PoaBridge", () => {
 		).resolves.toBe(true);
 	});
 
-	it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
-		"does not support %s",
-		async (tokenId) => {
-			const bridge = new PoaBridge({ env: "production" });
+	it.each([
+		"nep141:wrap.near",
+		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+	])("does not support %s", async (tokenId) => {
+		const bridge = new PoaBridge({ env: "production" });
 
-			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
-		},
-	);
+		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
+	});
 
-	it.each(["invalid_string", "nep141:unknown.omft.near"])(
-		"throws UnsupportedAssetIdError if invalid %s",
-		async (assetId) => {
-			const bridge = new PoaBridge({ env: "production" });
+	it.each([
+		// completely invalid tokenId
+		"invalid_string",
+		// matches POA bridge token pattern, but it is not supported
+		"nep141:unknown.omft.near",
+	])("throws UnsupportedAssetIdError if invalid %s", async (assetId) => {
+		const bridge = new PoaBridge({ env: "production" });
 
-			await expect(() => bridge.supports({ assetId })).rejects.toThrow(
-				UnsupportedAssetIdError,
-			);
+		await expect(bridge.supports({ assetId })).rejects.toThrow(
+			UnsupportedAssetIdError,
+		);
 
-			// It throws even if routeConfig is provided.
-			await expect(() =>
-				bridge.supports({
-					assetId,
-					routeConfig: createPoaBridgeRoute(Chains.Arbitrum),
-				}),
-			).rejects.toThrow(UnsupportedAssetIdError);
-		},
-	);
+		// It throws even if routeConfig is provided.
+		await expect(() =>
+			bridge.supports({
+				assetId,
+				routeConfig: createPoaBridgeRoute(Chains.Arbitrum),
+			}),
+		).rejects.toThrow(UnsupportedAssetIdError);
+	});
 
 	it.each([
 		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { PoaBridge } from "./poa-bridge";
+import { UnsupportedAssetIdError } from "../../classes/errors";
+import { createPoaBridgeRoute } from "../../lib/route-config-factory";
+import { Chains } from "../../lib/caip2";
+
+describe("PoaBridge", () => {
+	it.each([
+		"nep141:btc.omft.near",
+		"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+	])("supports %s", async (tokenId) => {
+		const bridge = new PoaBridge({ env: "production" });
+
+		await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(true);
+		await expect(
+			bridge.supports({
+				assetId: tokenId,
+				// For now, we can pass any `chain`. It's not validated.
+				routeConfig: createPoaBridgeRoute(Chains.Bitcoin),
+			}),
+		).resolves.toBe(true);
+	});
+
+	it.each(["nep245:v2_1.omni.hot.tg:56_11111111111111111111"])(
+		"does not support %s",
+		async (tokenId) => {
+			const bridge = new PoaBridge({ env: "production" });
+
+			await expect(bridge.supports({ assetId: tokenId })).resolves.toBe(false);
+		},
+	);
+
+	it.each(["invalid_string", "nep141:unknown.omft.near"])(
+		"throws UnsupportedAssetIdError if invalid %s",
+		async (assetId) => {
+			const bridge = new PoaBridge({ env: "production" });
+
+			await expect(() => bridge.supports({ assetId })).rejects.toThrow(
+				UnsupportedAssetIdError,
+			);
+
+			// It throws even if routeConfig is provided.
+			await expect(() =>
+				bridge.supports({
+					assetId,
+					routeConfig: createPoaBridgeRoute(Chains.Arbitrum),
+				}),
+			).rejects.toThrow(UnsupportedAssetIdError);
+		},
+	);
+
+	it.each([
+		"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
+		"nep141:wrap.near",
+	])(
+		"throws UnsupportedAssetIdError if routeConfig specified but assetId is not POA token",
+		async (assetId) => {
+			const bridge = new PoaBridge({ env: "production" });
+
+			await expect(() =>
+				bridge.supports({
+					assetId,
+					routeConfig: createPoaBridgeRoute(Chains.Bitcoin),
+				}),
+			).rejects.toThrow(UnsupportedAssetIdError);
+		},
+	);
+});

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
@@ -40,7 +40,7 @@ describe("PoaBridge", () => {
 				);
 
 				// It throws even if routeConfig is provided.
-				await expect(() =>
+				await expect(
 					bridge.supports({
 						assetId,
 						routeConfig: createPoaBridgeRoute(Chains.Arbitrum),
@@ -58,7 +58,7 @@ describe("PoaBridge", () => {
 			async (assetId) => {
 				const bridge = new PoaBridge({ env: "production" });
 
-				await expect(() =>
+				await expect(
 					bridge.supports({
 						assetId,
 						routeConfig: createPoaBridgeRoute(Chains.Bitcoin),

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.ts
@@ -8,7 +8,10 @@ import {
 	utils,
 } from "@defuse-protocol/internal-utils";
 import TTLCache from "@isaacs/ttlcache";
-import { MinWithdrawalAmountError } from "../../classes/errors";
+import {
+	MinWithdrawalAmountError,
+	UnsupportedAssetIdError,
+} from "../../classes/errors";
 import { BridgeNameEnum } from "../../constants/bridge-name-enum";
 import { RouteEnum } from "../../constants/route-enum";
 import type { IntentPrimitive } from "../../intents/shared-types";
@@ -26,6 +29,8 @@ import {
 	createWithdrawIntentPrimitive,
 	toPoaNetwork,
 } from "./poa-bridge-utils";
+import type { Chain } from "../../lib/caip2";
+import { parseDefuseAssetId } from "../../lib/parse-defuse-asset-id";
 
 export class PoaBridge implements Bridge {
 	protected env: NearIntentsEnv;
@@ -47,33 +52,47 @@ export class PoaBridge implements Bridge {
 	async supports(
 		params: Pick<WithdrawalParams, "assetId" | "routeConfig">,
 	): Promise<boolean> {
-		let result = true;
-
-		if ("routeConfig" in params && params.routeConfig != null) {
-			result &&= this.is(params.routeConfig);
-		}
-
-		try {
-			return result && this.parseAssetId(params.assetId) != null;
-		} catch {
+		if (params.routeConfig != null && !this.is(params.routeConfig)) {
 			return false;
 		}
+
+		const assetInfo = this.parseAssetId(params.assetId);
+		const isValid = assetInfo != null;
+
+		if (!isValid && params.routeConfig != null) {
+			throw new UnsupportedAssetIdError(
+				params.assetId,
+				"`assetId` does not match `routeConfig`.",
+			);
+		}
+		return isValid;
 	}
 
 	parseAssetId(assetId: string): ParsedAssetInfo | null {
-		const parsed = utils.parseDefuseAssetId(assetId);
-		if (
-			parsed.contractId.endsWith(
-				`.${configsByEnvironment[this.env].poaTokenFactoryContractID}`,
-			)
-		) {
-			return Object.assign(parsed, {
-				blockchain: contractIdToCaip2(parsed.contractId),
-				bridgeName: BridgeNameEnum.Poa,
-				address: "", // todo: derive address (or native)
-			});
+		const parsed = parseDefuseAssetId(assetId);
+		const contractIdSatisfies = parsed.contractId.endsWith(
+			`.${configsByEnvironment[this.env].poaTokenFactoryContractID}`,
+		);
+
+		if (!contractIdSatisfies) {
+			return null;
 		}
-		return null;
+
+		let blockchain: Chain;
+		try {
+			blockchain = contractIdToCaip2(parsed.contractId);
+		} catch {
+			throw new UnsupportedAssetIdError(
+				assetId,
+				"Asset belongs to unknown blockchain.",
+			);
+		}
+
+		return Object.assign(parsed, {
+			blockchain,
+			bridgeName: BridgeNameEnum.Poa,
+			address: "", // todo: derive address (or native)
+		});
 	}
 
 	createWithdrawalIntents(args: {

--- a/packages/intents-sdk/src/classes/errors.ts
+++ b/packages/intents-sdk/src/classes/errors.ts
@@ -83,3 +83,20 @@ export class TrustlineNotFoundError extends BaseError {
 		});
 	}
 }
+
+export type UnsupportedAssetIdErrorType = UnsupportedAssetIdError & {
+	name: "UnsupportedAssetIdError";
+};
+
+export class UnsupportedAssetIdError extends BaseError {
+	constructor(
+		public assetId: string,
+		details: string,
+	) {
+		super("Asset ID is not supported.", {
+			details,
+			metaMessages: [`Asset ID: ${assetId}`],
+			name: "UnsupportedAssetIdError",
+		});
+	}
+}

--- a/packages/intents-sdk/src/lib/parse-defuse-asset-id.ts
+++ b/packages/intents-sdk/src/lib/parse-defuse-asset-id.ts
@@ -1,0 +1,12 @@
+import { utils } from "@defuse-protocol/internal-utils";
+import { UnsupportedAssetIdError } from "../classes/errors";
+
+export function parseDefuseAssetId(
+	assetId: string,
+): utils.ParseDefuseAssetIdReturnType {
+	try {
+		return utils.parseDefuseAssetId(assetId);
+	} catch {
+		throw new UnsupportedAssetIdError(assetId, "Invalid asset id format.");
+	}
+}

--- a/packages/intents-sdk/src/sdk.test.ts
+++ b/packages/intents-sdk/src/sdk.test.ts
@@ -15,6 +15,8 @@ import {
 	createOmniWithdrawalRoute,
 } from "./lib/route-config-factory";
 import { IntentsSDK } from "./sdk";
+import { Chains } from "./lib/caip2";
+import { BridgeNameEnum } from "./constants/bridge-name-enum";
 
 const intentSigner = createIntentSignerViem(
 	privateKeyToAccount(generatePrivateKey()),
@@ -759,5 +761,41 @@ describe.concurrent.skip("omni_bridge", () => {
 		});
 
 		await expect(fee).rejects.toThrow(FeeExceedsAmountError);
+	});
+});
+
+describe("sdk.parseAssetId()", () => {
+	it.each([
+		[
+			"nep141:btc.omft.near",
+			{ bridgeName: BridgeNameEnum.Poa, blockchain: Chains.Bitcoin },
+		],
+		[
+			"nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+			{ bridgeName: BridgeNameEnum.Poa, blockchain: Chains.Ethereum },
+		],
+		[
+			"nep245:v2_1.omni.hot.tg:137_3hpYoaLtt8MP1Z2GH1U473DMRKgr",
+			{ bridgeName: BridgeNameEnum.Hot, blockchain: Chains.Polygon },
+		],
+		[
+			"nep245:v2_1.omni.hot.tg:1117_",
+			{ bridgeName: BridgeNameEnum.Hot, blockchain: Chains.TON },
+		],
+		[
+			"nep141:wrap.near",
+			{ bridgeName: BridgeNameEnum.None, blockchain: Chains.Near },
+		],
+		/* Even though this is a valid `assetId`, but it's not supported in SDK yet.
+		[
+			"nep245:intents.near:nep141:wrap.near",
+			{ bridgeName: BridgeNameEnum.None, blockchain: Chains.Near },
+		],
+		*/
+	])("returns parsed asset info", (assetId, assetInfo) => {
+		const sdk = new IntentsSDK({ referral: "", intentSigner });
+		expect(sdk.parseAssetId(assetId)).toEqual(
+			expect.objectContaining(assetInfo),
+		);
 	});
 });

--- a/packages/intents-sdk/src/sdk.test.ts
+++ b/packages/intents-sdk/src/sdk.test.ts
@@ -782,6 +782,24 @@ describe("sdk.parseAssetId()", () => {
 			"nep245:v2_1.omni.hot.tg:1117_",
 			{ bridgeName: BridgeNameEnum.Hot, blockchain: Chains.TON },
 		],
+		/* todo: uncomment when Omni is enabled
+		[
+			"nep141:sol.omdep.near",
+			{ bridgeName: BridgeNameEnum.Omni, blockchain: Chains.Solana },
+		],
+		[
+			"nep141:aaaaaa20d9e0e2461697782ef11675f668207961.factory.bridge.near",
+			{ bridgeName: BridgeNameEnum.Omni, blockchain: Chains.Ethereum },
+		],
+		[
+			"nep141:eth.bridge.near",
+			{ bridgeName: BridgeNameEnum.Omni, blockchain: Chains.Ethereum },
+		],
+		[
+			"nep141:nbtc.bridge.near",
+			{ bridgeName: BridgeNameEnum.Omni, blockchain: Chains.Bitcoin },
+		],
+		 */
 		[
 			"nep141:wrap.near",
 			{ bridgeName: BridgeNameEnum.None, blockchain: Chains.Near },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added UnsupportedAssetIdError for clearer error reporting on invalid or mismatched asset IDs.
- Improvements
  - Stricter assetId validation across bridges; supports() now enforces supported standards and fails explicitly on mismatches.
  - Unified asset ID parsing with clearer, user-facing error messages.
- Performance
  - POA bridge caches supported tokens for 30 seconds to reduce network calls.
- Tests
  - Added comprehensive unit tests for bridges and SDK asset parsing.
- Chores
  - Minor release for @defuse-protocol/intents-sdk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->