### PR TITLE
fix: wait for completion to stop retrying due to BD non indexed transfer

### DIFF
--- a/.changeset/silver-flies-sleep.md
+++ b/.changeset/silver-flies-sleep.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": patch
+---
+
+fix wait for withdrawal completion retry stoppage

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -388,10 +388,7 @@ export class OmniBridge implements Bridge {
 			{
 				...(args.retryOptions ?? RETRY_CONFIGS.FIVE_MINS_STEADY),
 				handleError: (err, ctx) => {
-					if (
-						err instanceof OmniTransferNotFoundError ||
-						err === args.signal?.reason
-					) {
+					if (err === args.signal?.reason) {
 						ctx.abort();
 					}
 				},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed premature stopping in the “wait for withdrawal completion” flow. Retries no longer abort on transient missing-transfer errors and only stop when explicitly canceled. This improves reliability and consistency of withdrawal tracking, reducing false failures and the need for manual retries.

* **Chores**
  * Released a patch update for @defuse-protocol/intents-sdk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->