### PR TITLE
feat: remove legacy Stellar raw signature support

### DIFF
--- a/.changeset/grumpy-moles-do.md
+++ b/.changeset/grumpy-moles-do.md
@@ -1,0 +1,6 @@
+---
+"@defuse-protocol/internal-utils": minor
+"@defuse-protocol/intents-sdk": minor
+---
+
+Remove STELLAR_RAW signature type support.

--- a/packages/internal-utils/src/types/walletMessage.ts
+++ b/packages/internal-utils/src/types/walletMessage.ts
@@ -55,7 +55,7 @@ export type StellarMessage = {
 };
 
 export type StellarSignatureData = {
-	type: "STELLAR_RAW" | "STELLAR_SEP53";
+	type: "STELLAR_SEP53";
 	signatureData: Uint8Array;
 	signedData: StellarMessage;
 };

--- a/packages/internal-utils/src/utils/prepareBroadcastRequest.test.ts
+++ b/packages/internal-utils/src/utils/prepareBroadcastRequest.test.ts
@@ -100,23 +100,6 @@ describe("prepareSwapSignedData()", () => {
 		).toMatchSnapshot();
 	});
 
-	it("should return the correct signed data for a Stellar signature", () => {
-		const signature: StellarSignatureData = {
-			type: "STELLAR_RAW",
-			signatureData: Buffer.from("deadbeef1c", "hex"),
-			signedData: {
-				message: JSON.stringify({ foo: "bar" }),
-			},
-		};
-
-		expect(
-			prepareSwapSignedData(signature, {
-				userAddress: "GDZ7T36V5BBWLZTM7NGZYWJYRIYBFXFVYQT3EOGO7G4JCEO6DBYL7DC2",
-				userChainType: "stellar",
-			}),
-		).toMatchSnapshot();
-	});
-
 	it("should return the correct signed data for a Stellar SEP-0053 signature", () => {
 		const signature: StellarSignatureData = {
 			type: "STELLAR_SEP53",

--- a/packages/internal-utils/src/utils/prepareBroadcastRequest.ts
+++ b/packages/internal-utils/src/utils/prepareBroadcastRequest.ts
@@ -66,22 +66,6 @@ export function prepareSwapSignedData(
 			};
 		}
 
-		case "STELLAR_RAW": {
-			assert(
-				userInfo.userChainType === "stellar",
-				"User chain and signature chain must match",
-			);
-			return {
-				standard: "raw_ed25519",
-				payload: signature.signedData.message,
-				// We should encode the Stellar address to base58
-				public_key: `ed25519:${base58.encode(
-					stellarAddressToBytes(userInfo.userAddress),
-				)}`,
-				signature: transformED25519Signature(signature.signatureData),
-			};
-		}
-
 		case "STELLAR_SEP53": {
 			assert(
 				userInfo.userChainType === "stellar",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Stellar signing support to SEP-53 only; RAW signatures are no longer accepted. Ensure integrations use SEP-53 for Stellar transactions.
* **Chores**
  * Bumped @defuse-protocol/internal-utils and @defuse-protocol/intents-sdk minor versions and recorded the public API change.
* **Tests**
  * Removed tests for the deprecated Stellar RAW signature path; retained SEP-53 coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->