### PR TITLE
Update copyright to 2025 NEAR Foundation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 NEAR Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ Once that PR is merged, the GitHub Action will automatically:
 
 ## License
 
-[MIT](LICENSE)
+[MIT](LICENSE) © 2025 NEAR Foundation

--- a/packages/contract-types/README.md
+++ b/packages/contract-types/README.md
@@ -68,4 +68,4 @@ pnpm run lint
 
 ## License
 
-MIT
+MIT License © 2025 NEAR Foundation

--- a/packages/intents-sdk/README.md
+++ b/packages/intents-sdk/README.md
@@ -871,4 +871,4 @@ This package is part of Near Intents SDK monorepo. Please refer to the main repo
 
 ## License
 
-MIT
+MIT License © 2025 NEAR Foundation


### PR DESCRIPTION
## Summary
- add an MIT LICENSE file that credits 2025 NEAR Foundation
- update repository documentation to reference the new copyright owner

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68cbd53092d4832c9da9a82eb51b2ad4