### PR TITLE
feat(intents-sdk): make `retryOptions` configurable for orchestrated `processWithdrawal()`

### DIFF
--- a/.changeset/slimy-guests-fold.md
+++ b/.changeset/slimy-guests-fold.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Make `retryOptions` configurable in orchestrated `processWithdrawal()`.

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -499,8 +499,8 @@ export class IntentsSDK implements IIntentsSDK {
 		const destinationTx = await this.waitForWithdrawalCompletion({
 			withdrawalParams,
 			intentTx,
+			retryOptions: args.retryOptions ?? RETRY_CONFIGS.FIVE_MINS_STEADY,
 			logger: args.logger,
-			retryOptions: RETRY_CONFIGS.FIVE_MINS_STEADY,
 		});
 
 		if (!Array.isArray(args.withdrawalParams)) {

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -69,6 +69,7 @@ export type ProcessWithdrawalArgs<
 		onBeforePublishIntent?: OnBeforePublishIntentHook;
 	};
 	referral?: string;
+	retryOptions?: RetryOptions;
 	logger?: ILogger;
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable retry behavior for withdrawals. The processWithdrawal API now accepts an optional retryOptions parameter, letting you customize retry timing while preserving the previous default when not provided.
  - Enables finer control over how long and how often the withdrawal completion is retried, improving adaptability to different environments and reliability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->