### PR TITLE
fix(intents-sdk): update HotBridge import from omni-sdk

### DIFF
--- a/.changeset/brave-pears-cross.md
+++ b/.changeset/brave-pears-cross.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": patch
+---
+
+Fix import HotBridge from @hot-labs/omni-sdk.

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -9,7 +9,7 @@ import {
 	nearFailoverRpcProvider,
 	solverRelay,
 } from "@defuse-protocol/internal-utils";
-import hotOmniSdk from "@hot-labs/omni-sdk";
+import { HotBridge as hotLabsOmniSdk_HotBridge } from "@hot-labs/omni-sdk";
 import { stringify } from "viem";
 import { AuroraEngineBridge } from "./bridges/aurora-engine-bridge/aurora-engine-bridge";
 import { DirectBridge } from "./bridges/direct-bridge/direct-bridge";
@@ -113,7 +113,7 @@ export class IntentsSDK implements IIntentsSDK {
 			new HotBridge({
 				env: this.env,
 				solverRelayApiKey: this.solverRelayApiKey,
-				hotSdk: new hotOmniSdk.HotBridge({
+				hotSdk: new hotLabsOmniSdk_HotBridge({
 					logger: console,
 					evmRpc: evmRpcUrls,
 					// 1. HotBridge from omni-sdk does not support FailoverProvider.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the import and initialization of a third‑party bridge within the Intents SDK to prevent startup issues and improve reliability. No changes to the public API.

* **Chores**
  * Prepared a patch release with updated versioning and release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->