### PR TITLE
fix(poa-bridge): use property-based matching for withdrawal completion

### DIFF
--- a/.changeset/fix-poa-withdrawal-matching.md
+++ b/.changeset/fix-poa-withdrawal-matching.md
@@ -1,0 +1,6 @@
+---
+"@defuse-protocol/intents-sdk": patch
+"@defuse-protocol/internal-utils": patch
+---
+
+Fix POA bridge withdrawal matching to use assetId instead of index.

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
@@ -12,7 +12,6 @@ import type { IntentPrimitive } from "../../intents/shared-types";
 import type {
 	Bridge,
 	FeeEstimation,
-	NearTxInfo,
 	QuoteOptions,
 	RouteConfig,
 	TxNoInfo,
@@ -203,10 +202,7 @@ export class AuroraEngineBridge implements Bridge {
 		};
 	}
 
-	async waitForWithdrawalCompletion(_args: {
-		tx: NearTxInfo;
-		index: number;
-	}): Promise<TxNoInfo> {
+	async waitForWithdrawalCompletion(): Promise<TxNoInfo> {
 		return { hash: null };
 	}
 }

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.ts
@@ -301,10 +301,7 @@ export class DirectBridge implements Bridge {
 		return exist;
 	}
 
-	async waitForWithdrawalCompletion(args: {
-		tx: NearTxInfo;
-		index: number;
-	}): Promise<TxInfo> {
+	async waitForWithdrawalCompletion(args: { tx: NearTxInfo }): Promise<TxInfo> {
 		return { hash: args.tx.hash };
 	}
 }

--- a/packages/intents-sdk/src/bridges/intents-bridge/intents-bridge.ts
+++ b/packages/intents-sdk/src/bridges/intents-bridge/intents-bridge.ts
@@ -77,10 +77,7 @@ export class IntentsBridge implements Bridge {
 		};
 	}
 
-	async waitForWithdrawalCompletion(args: {
-		tx: NearTxInfo;
-		index: number;
-	}): Promise<TxInfo> {
+	async waitForWithdrawalCompletion(args: { tx: NearTxInfo }): Promise<TxInfo> {
 		return { hash: args.tx.hash };
 	}
 }

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -637,7 +637,6 @@ export class OmniBridge implements Bridge {
 	async waitForWithdrawalCompletion(args: {
 		tx: NearTxInfo;
 		index: number;
-		routeConfig: RouteConfig;
 		signal?: AbortSignal;
 		retryOptions?: RetryOptions;
 	}): Promise<TxInfo | TxNoInfo> {

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.ts
@@ -203,14 +203,16 @@ export class PoaBridge implements Bridge {
 
 	async waitForWithdrawalCompletion(args: {
 		tx: NearTxInfo;
-		index: number;
+		withdrawalParams: WithdrawalParams;
 		signal?: AbortSignal;
 		retryOptions?: RetryOptions;
 		logger?: ILogger;
 	}): Promise<TxInfo> {
 		const withdrawalStatus = await poaBridge.waitForWithdrawalCompletion({
 			txHash: args.tx.hash,
-			index: args.index,
+			withdrawalCriteria: {
+				assetId: args.withdrawalParams.assetId,
+			},
 			signal: args.signal ?? new AbortController().signal,
 			retryOptions: args.retryOptions,
 			baseURL: configsByEnvironment[this.env].poaBridgeBaseURL,

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -393,27 +393,19 @@ export class IntentsSDK implements IIntentsSDK {
 		withdrawalParams: WithdrawalParams[];
 		intentTx: NearTxInfo;
 	}): WithdrawalIdentifier[] {
-		const indexes = new Map<string, number>(
-			zip(
-				withdrawalParams.map((w) => {
-					const routeConfig = determineRouteConfig(this, w);
-					return routeConfig.route;
-				}),
-				Array(withdrawalParams.length).fill(0),
-			),
-		);
+		const indexes = new Map<string, number>();
 
 		return withdrawalParams.map((w): WithdrawalIdentifier => {
 			const routeConfig = determineRouteConfig(this, w);
 			const route = routeConfig.route;
 
-			const index = indexes.get(route);
-			assert(index != null, "Index is not found for route");
-			indexes.set(route, index + 1);
+			const currentIndex = indexes.get(route) ?? 0;
+			indexes.set(route, currentIndex + 1);
 
 			return {
 				routeConfig: routeConfig,
-				index,
+				index: currentIndex,
+				withdrawalParams: w,
 				tx: intentTx,
 			};
 		});
@@ -456,6 +448,7 @@ export class IntentsSDK implements IIntentsSDK {
 						return bridge.waitForWithdrawalCompletion({
 							tx: args.intentTx,
 							index: wid.index,
+							withdrawalParams: wid.withdrawalParams,
 							routeConfig: wid.routeConfig,
 							signal: args.signal,
 							retryOptions: args.retryOptions,

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -382,6 +382,7 @@ export interface Bridge {
 	waitForWithdrawalCompletion(args: {
 		tx: NearTxInfo;
 		index: number;
+		withdrawalParams: WithdrawalParams;
 		routeConfig: RouteConfig;
 		signal?: AbortSignal;
 		retryOptions?: RetryOptions;
@@ -392,6 +393,7 @@ export interface Bridge {
 export interface WithdrawalIdentifier {
 	routeConfig: RouteConfig;
 	index: number;
+	withdrawalParams: WithdrawalParams;
 	tx: NearTxInfo;
 }
 

--- a/packages/internal-utils/src/poaBridge/errors/withdrawal.ts
+++ b/packages/internal-utils/src/poaBridge/errors/withdrawal.ts
@@ -1,6 +1,7 @@
 import { BaseError } from "../../errors/base";
 import { serialize } from "../../utils/serialize";
 import type * as types from "../poaBridgeHttpClient/types";
+import type { WithdrawalCriteria } from "../waitForWithdrawalCompletion";
 
 export type PoaWithdrawalInvariantErrorType = PoaWithdrawalInvariantError & {
 	name: "PoaWithdrawalError";
@@ -10,12 +11,12 @@ export class PoaWithdrawalInvariantError extends BaseError {
 		public details: string,
 		public result: types.WithdrawalStatusResponseOk["result"],
 		public txHash: string,
-		public index: number,
+		public withdrawalCriteria: WithdrawalCriteria,
 	) {
 		super("Withdrawal is not in an expected shape.", {
 			metaMessages: [
 				`TxHash: ${txHash}`,
-				`Index: ${index}`,
+				`Criteria: ${serialize(withdrawalCriteria)}`,
 				`Result: ${serialize(result)}`,
 			],
 			details,
@@ -30,11 +31,14 @@ export type PoaWithdrawalNotFoundErrorType = PoaWithdrawalNotFoundError & {
 export class PoaWithdrawalNotFoundError extends BaseError {
 	constructor(
 		public txHash: string,
-		public index: number,
+		public withdrawalCriteria: WithdrawalCriteria,
 		cause: unknown,
 	) {
 		super("POA withdrawal not found.", {
-			metaMessages: [`TxHash: ${txHash}`, `Index: ${index}`],
+			metaMessages: [
+				`TxHash: ${txHash}`,
+				`Criteria: ${serialize(withdrawalCriteria)}`,
+			],
 			name: "PoaWithdrawalNotFoundError",
 			cause,
 		});
@@ -48,12 +52,12 @@ export class PoaWithdrawalPendingError extends BaseError {
 	constructor(
 		public result: types.WithdrawalStatusResponseOk["result"],
 		public txHash: string,
-		public index: number,
+		public withdrawalCriteria: WithdrawalCriteria,
 	) {
 		super("POA withdrawal is still pending.", {
 			metaMessages: [
 				`TxHash: ${txHash}`,
-				`Index: ${index}`,
+				`Criteria: ${serialize(withdrawalCriteria)}`,
 				`Result: ${serialize(result)}`,
 			],
 			name: "PoaWithdrawalPendingError",


### PR DESCRIPTION
## Summary
- Replace index-based withdrawal matching with assetId-based matching
- POA API returns withdrawals in unpredictable order, so index-based matching was unreliable
- Add `withdrawalParams` to `WithdrawalIdentifier` to enable property-based matching

Closes #271