### PR TITLE
ci: reduce duplicate work in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,52 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Setup PNPM
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Lint
-        run: pnpm run lint
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Test
-        run: pnpm run test
-
-  type-check:
-    name: Type Check
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -92,8 +48,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Lint
+        run: pnpm run lint
+
       - name: Build
         run: pnpm run build
 
       - name: Type check
         run: pnpm run typecheck
+
+      - name: Test
+        run: pnpm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,16 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [CI]
+    branches: [main]
+    types: [completed]
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       pull-requests: write
@@ -16,7 +18,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -43,16 +44,10 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
-
-      - name: Lint
-        run: pnpm run lint
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm run build
-
-      - name: Test
-        run: pnpm run test
 
       - name: Create release PR or publish to npm
         id: changesets


### PR DESCRIPTION
## Summary
- Consolidate CI into single job (was running two parallel jobs that both built)
- Release workflow now triggers after CI succeeds via `workflow_run` instead of duplicating checks
- Remove redundant lint/test from release workflow (CI already validated main)

## Before
- PR: CI runs (2 parallel jobs, both build)
- Push to main: CI runs + Release runs (both do lint/build/test)

## After
- PR: CI runs (single job: lint → build → typecheck → test)
- Push to main: CI runs → Release runs after CI succeeds (only build + publish)