### PR TITLE
feat(intents-sdk): add feature flag to bypass destination token check for omft tokens

### DIFF
--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.test.ts
@@ -166,6 +166,46 @@ describe("OmniBridge", () => {
 				},
 			);
 		});
+
+		describe("feature: bypassDestinationTokenCheckForOmftTokens", () => {
+			it("bypasses destination token check when enabled", async () => {
+				const nearProvider = nearFailoverRpcProvider({
+					urls: PUBLIC_NEAR_RPC_URLS,
+				});
+
+				const bridge = new OmniBridge({
+					env: "production",
+					nearProvider,
+					bypassDestinationTokenCheckForOmftTokens: true,
+				});
+
+				const assetId = "nep141:btc.omft.near";
+				const routeConfig = createOmniBridgeRoute(Chains.Solana);
+
+				await expect(bridge.supports({ assetId, routeConfig })).resolves.toBe(
+					true,
+				);
+			});
+
+			it("throws TokenNotFoundInDestinationChainError when disabled (default)", async () => {
+				const nearProvider = nearFailoverRpcProvider({
+					urls: PUBLIC_NEAR_RPC_URLS,
+				});
+
+				const bridge = new OmniBridge({
+					env: "production",
+					nearProvider,
+					// bypassDestinationTokenCheckForOmftTokens: undefined
+				});
+
+				const assetId = "nep141:btc.omft.near";
+				const routeConfig = createOmniBridgeRoute(Chains.Solana);
+
+				await expect(bridge.supports({ assetId, routeConfig })).rejects.toThrow(
+					TokenNotFoundInDestinationChainError,
+				);
+			});
+		});
 	});
 
 	describe("validateWithdrawal()", () => {

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -78,6 +78,15 @@ export interface IntentsSDKConfig {
 	rpc?: PartialRPCEndpointMap;
 	referral: string;
 	solverRelayApiKey?: string;
+	features?: {
+		/**
+		 * Bypass the destination token check for *.omft.near tokens when using Omni Bridge.
+		 * This is needed for migrated POA tokens that are now routed through Omni Bridge
+		 * but haven't been registered in the Omni Bridge contract yet.
+		 * When enabled, users must specify `routeConfig.chain` explicitly.
+		 */
+		omniBridgeBypassDestinationTokenCheckForOmftTokens?: boolean;
+	};
 }
 
 export class IntentsSDK implements IIntentsSDK {
@@ -143,6 +152,8 @@ export class IntentsSDK implements IIntentsSDK {
 				env: this.env,
 				nearProvider,
 				solverRelayApiKey: this.solverRelayApiKey,
+				bypassDestinationTokenCheckForOmftTokens:
+					args.features?.omniBridgeBypassDestinationTokenCheckForOmftTokens,
 			}),
 			new DirectBridge({
 				env: this.env,


### PR DESCRIPTION
## Summary
- Add `omniBridgeBypassDestinationTokenCheckForOmftTokens` feature flag to `IntentsSDKConfig`
- When enabled, bypasses the destination token check in OmniBridge for `*.omft.near` tokens
- This is needed for migrated POA tokens that are now routed through Omni Bridge but haven't been registered in the Omni Bridge contract yet

## Test plan
- [x] Unit tests added for feature flag enabled/disabled behavior
- [x] All existing tests pass
- [x] TypeScript types check