### PR TITLE
fix(poa-bridge): match withdrawal status by near_token_id instead of defuse_asset_identifier

### DIFF
--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.test.ts
@@ -552,5 +552,49 @@ describe("PoaBridge", () => {
 				txHash: "btc-tx-hash",
 			});
 		});
+
+		it("matches withdrawal by near_token_id when defuse_asset_identifier differs from assetId format", async () => {
+			// Regression test: POA API returns defuse_asset_identifier in chain-native format
+			// (e.g., "zec:mainnet:native") which differs from assetId format ("nep141:zec.omft.near").
+			// Matching must use near_token_id, not defuse_asset_identifier.
+			vi.mocked(poaBridge.httpClient.getWithdrawalStatus).mockResolvedValue({
+				withdrawals: [
+					{
+						status: "COMPLETED",
+						data: {
+							tx_hash: "near-tx-hash",
+							transfer_tx_hash: "zec-tx-hash",
+							chain: "zec:mainnet",
+							defuse_asset_identifier: "zec:mainnet:native",
+							near_token_id: "zec.omft.near",
+							decimals: 8,
+							amount: 474270,
+							account_id: "test.near",
+							address: "native",
+							created: "2024-01-01T00:00:00Z",
+						},
+					},
+				],
+			});
+
+			const bridge = new PoaBridge({ env: "production" });
+
+			const result = await bridge.describeWithdrawal({
+				landingChain: Chains.Zcash,
+				index: 0,
+				withdrawalParams: {
+					assetId: "nep141:zec.omft.near",
+					amount: 474270n,
+					destinationAddress: "t1abc123",
+					feeInclusive: false,
+				},
+				tx: { hash: "near-tx-hash", accountId: "test.near" },
+			});
+
+			expect(result).toEqual({
+				status: "completed",
+				txHash: "zec-tx-hash",
+			});
+		});
 	});
 });

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge.ts
@@ -308,5 +308,9 @@ function findMatchingWithdrawal(
 	withdrawals: WithdrawalStatusResponse["withdrawals"],
 	assetId: string,
 ): WithdrawalStatusResponse["withdrawals"][number] | undefined {
-	return withdrawals.find((w) => w.data.defuse_asset_identifier === assetId);
+	// POA bridge only supports NEP-141 tokens. The API returns `near_token_id`
+	// (e.g., "zec.omft.near") which we prefix with "nep141:" to match assetId format.
+	// Note: `defuse_asset_identifier` cannot be used as it contains chain-native
+	// format (e.g., "zec:mainnet:native") which differs from the assetId format.
+	return withdrawals.find((w) => `nep141:${w.data.near_token_id}` === assetId);
 }


### PR DESCRIPTION
## Summary
- Fix withdrawal status polling never completing for POA bridge tokens (e.g., Zcash)
- The POA API returns `defuse_asset_identifier` in chain-native format (e.g., `"zec:mainnet:native"`) which differs from the `assetId` format used internally (`"nep141:zec.omft.near"`)
- Changed matching logic to use `near_token_id` field instead

## Test plan
- [x] Added regression test with realistic mock data where `defuse_asset_identifier` differs from `assetId`
- [x] All existing tests pass (648 tests)
- [x] TypeScript type check passes