### PR TITLE
fix(solver-relay): detect and throw on intent settlement failure

### DIFF
--- a/.changeset/handle-settlement-failure.md
+++ b/.changeset/handle-settlement-failure.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/internal-utils": patch
+---
+
+Detect and throw IntentSettlementError when intent settlement fails on-chain (e.g., out of gas) instead of polling until timeout.

--- a/packages/internal-utils/src/solverRelay/errors/intentSettlement.ts
+++ b/packages/internal-utils/src/solverRelay/errors/intentSettlement.ts
@@ -11,6 +11,9 @@ export class IntentSettlementError extends BaseError {
 			metaMessages: [
 				`Status: ${result.status}`,
 				`Intent hash: ${result.intent_hash}`,
+				...("data" in result && result.data
+					? [`Tx hash: ${result.data.hash}`]
+					: []),
 			],
 			name: "IntentSettlementError",
 		});

--- a/packages/internal-utils/src/solverRelay/solverRelayHttpClient/types.ts
+++ b/packages/internal-utils/src/solverRelay/solverRelayHttpClient/types.ts
@@ -129,5 +129,7 @@ export type GetStatusResponse = JSONRPCResponse<
 	| {
 			status: "NOT_FOUND_OR_NOT_VALID";
 			intent_hash: string;
+			status_details?: "FAILED";
+			data?: { hash: string };
 	  }
 >;


### PR DESCRIPTION
## Summary
- Detect when intent settlement fails on-chain (e.g., out of gas) via `status_details: "FAILED"` in API response
- Throw `IntentSettlementError` immediately instead of polling until timeout (356s)
- Include failed tx hash in error message for debugging

## Test plan
- [x] Added test for settlement failure case
- [x] All existing tests pass
- [x] TypeScript types updated for new API response fields