### PR TITLE
chore: add biome extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["biomejs.biome"]
+}


### PR DESCRIPTION
## Summary
- Adds `.vscode/extensions.json` with Biome extension recommendation
- VS Code will prompt users to install the Biome extension when opening the project

## Test plan
- [x] Open project in VS Code and verify extension recommendation prompt appears