### PR TITLE
fix: use correct biome code action for auto-fix on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "biomejs.biome",
     "editor.codeActionsOnSave": {
-      "quickfix.biome": "explicit",
+      "source.fixAll.biome": "explicit",
       "source.organizeImports.biome": "explicit"
     }
   }


### PR DESCRIPTION
## Summary
- Changes `quickfix.biome` to `source.fixAll.biome` in VS Code settings
- The previous code action name was deprecated

## Test plan
- [x] Open a file with lint issues and save — verify auto-fix applies