### PR TITLE
feat(intents-sdk): add sendSignedIntents method

### DIFF
--- a/.changeset/add-send-signed-intents.md
+++ b/.changeset/add-send-signed-intents.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Add `sendSignedIntents()` method to send pre-signed `MultiPayload[]` directly to relay without creating/signing new intents

--- a/packages/intents-sdk/src/intents/intent-executer-impl/intent-executer.ts
+++ b/packages/intents-sdk/src/intents/intent-executer-impl/intent-executer.ts
@@ -148,6 +148,21 @@ export class IntentExecuter<Ticket> implements IIntentExecuter<Ticket> {
 			signal: ctx?.signal,
 		});
 	}
+
+	async sendSignedIntents(params: {
+		multiPayloads: MultiPayload[];
+		quoteHashes?: string[];
+	}): Promise<{ tickets: Ticket[] }> {
+		const tickets = await this.intentRelayer.publishIntents(
+			{
+				multiPayloads: params.multiPayloads,
+				quoteHashes: params.quoteHashes ?? [],
+			},
+			{ logger: this.logger },
+		);
+
+		return { tickets };
+	}
 }
 
 async function mergeIntentPayloads(

--- a/packages/intents-sdk/src/sdk.sendSignedIntents.test.ts
+++ b/packages/intents-sdk/src/sdk.sendSignedIntents.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+import { IntentRelayerPublic } from "./intents/intent-relayer-impl/intent-relayer-public";
+import { IntentsSDK } from "./sdk";
+import type { MultiPayload } from "./intents/shared-types";
+
+describe("sdk.sendSignedIntents()", () => {
+	it("sends single pre-signed intent", async () => {
+		const { sdk, intentRelayer } = setupMocks();
+		noPublish(intentRelayer);
+
+		const multiPayload: MultiPayload = {
+			payload: "test-payload-1",
+			signature: "test-signature-1",
+			standard: "erc191",
+		};
+
+		void sdk.sendSignedIntents({ multiPayloads: [multiPayload] });
+
+		await vi.waitFor(() =>
+			expect(intentRelayer.publishIntents).toHaveBeenCalledOnce(),
+		);
+		expect(intentRelayer.publishIntents).toHaveBeenCalledWith(
+			{
+				multiPayloads: [multiPayload],
+				quoteHashes: [],
+			},
+			expect.any(Object),
+		);
+	});
+
+	it("sends multiple pre-signed intents", async () => {
+		const { sdk, intentRelayer } = setupMocks();
+		noPublish(intentRelayer);
+
+		const multiPayloads: MultiPayload[] = [
+			{ payload: "payload-1", signature: "sig-1", standard: "erc191" },
+			{ payload: "payload-2", signature: "sig-2", standard: "erc191" },
+			{ payload: "payload-3", signature: "sig-3", standard: "erc191" },
+		];
+
+		void sdk.sendSignedIntents({ multiPayloads });
+
+		await vi.waitFor(() =>
+			expect(intentRelayer.publishIntents).toHaveBeenCalledOnce(),
+		);
+		expect(intentRelayer.publishIntents).toHaveBeenCalledWith(
+			{
+				multiPayloads,
+				quoteHashes: [],
+			},
+			expect.any(Object),
+		);
+	});
+
+	it("returns correct tickets", async () => {
+		const { sdk, intentRelayer } = setupMocks();
+		const expectedTickets = ["hash-1", "hash-2"];
+		vi.mocked(intentRelayer.publishIntents).mockResolvedValueOnce(
+			expectedTickets,
+		);
+
+		const result = await sdk.sendSignedIntents({
+			multiPayloads: [
+				{ payload: "p1", signature: "s1", standard: "erc191" },
+				{ payload: "p2", signature: "s2", standard: "erc191" },
+			],
+		});
+
+		expect(result.tickets).toEqual(expectedTickets);
+	});
+
+	it("passes quoteHashes to relayer", async () => {
+		const { sdk, intentRelayer } = setupMocks();
+		noPublish(intentRelayer);
+
+		const quoteHashes = ["quote-hash-1", "quote-hash-2"];
+
+		void sdk.sendSignedIntents({
+			multiPayloads: [{ payload: "p", signature: "s", standard: "erc191" }],
+			quoteHashes,
+		});
+
+		await vi.waitFor(() =>
+			expect(intentRelayer.publishIntents).toHaveBeenCalledOnce(),
+		);
+		expect(intentRelayer.publishIntents).toHaveBeenCalledWith(
+			expect.objectContaining({ quoteHashes }),
+			expect.any(Object),
+		);
+	});
+});
+
+function setupMocks() {
+	const intentRelayer = new IntentRelayerPublic({ env: "production" });
+	vi.spyOn(intentRelayer, "publishIntents");
+
+	class MockSDK extends IntentsSDK {
+		constructor(...args: ConstructorParameters<typeof IntentsSDK>) {
+			super(...args);
+			this.intentRelayer = intentRelayer;
+		}
+	}
+
+	const sdk = new MockSDK({ referral: "" });
+
+	return { sdk, intentRelayer };
+}
+
+function noPublish(intentRelayer: IntentRelayerPublic) {
+	vi.mocked(intentRelayer.publishIntents).mockImplementation(
+		async () => new Promise(() => {}),
+	);
+}

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -31,6 +31,7 @@ import type {
 	IntentHash,
 	IntentPrimitive,
 	IntentRelayParamsFactory,
+	MultiPayload,
 } from "./intents/shared-types";
 import { zip } from "./lib/array";
 import { type Chain, Chains } from "./lib/caip2";
@@ -564,6 +565,22 @@ export class IntentsSDK implements IIntentsSDK {
 		}
 
 		throw new Error(`Cannot determine bridge for assetId = ${assetId}`);
+	}
+
+	public async sendSignedIntents(args: {
+		multiPayloads: MultiPayload[];
+		quoteHashes?: string[];
+		logger?: ILogger;
+	}): Promise<{ tickets: IntentHash[] }> {
+		const tickets = await this.intentRelayer.publishIntents(
+			{
+				multiPayloads: args.multiPayloads,
+				quoteHashes: args.quoteHashes ?? [],
+			},
+			{ logger: args.logger },
+		);
+
+		return { tickets };
 	}
 
 	public async signAndSendIntent(

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -131,6 +131,12 @@ export type ProcessWithdrawalArgs<
 export interface IIntentsSDK {
 	setIntentSigner(signer: IIntentSigner): void;
 
+	sendSignedIntents(args: {
+		multiPayloads: MultiPayload[];
+		quoteHashes?: string[];
+		logger?: ILogger;
+	}): Promise<{ tickets: IntentHash[] }>;
+
 	signAndSendIntent(args: SignAndSendArgs): Promise<IntentPublishResult>;
 
 	waitForIntentSettlement(args: {


### PR DESCRIPTION
## Summary
- Add `sendSignedIntents()` method to send pre-signed `MultiPayload[]` directly to relay
- Useful for scenarios where intents are signed externally and need to be published without re-signing

## Test plan
- [x] Unit tests added for single/multiple payloads and quoteHashes passthrough
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] `pnpm build` passes