### PR TITLE
feat(intents-sdk): add destinationMemo support for internal transfers

### DIFF
--- a/.changeset/memo-internal-transfer.md
+++ b/.changeset/memo-internal-transfer.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Add `destinationMemo` support for internal transfers (intents route). The memo is now passed through to the transfer intent's `memo` field.

--- a/packages/intents-sdk/src/bridges/intents-bridge/intents-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/intents-bridge/intents-bridge.test.ts
@@ -2,8 +2,62 @@ import { describe, expect, it } from "vitest";
 import { InvalidDestinationAddressForWithdrawalError } from "../../classes/errors";
 import { zeroAddress } from "viem";
 import { IntentsBridge } from "./intents-bridge";
+import { RouteEnum } from "../../constants/route-enum";
 
 describe("IntentsBridge", () => {
+	describe("createWithdrawalIntents()", () => {
+		it("includes memo in transfer intent when destinationMemo is provided", async () => {
+			const bridge = new IntentsBridge();
+			const intents = await bridge.createWithdrawalIntents({
+				withdrawalParams: {
+					assetId: "nep141:wrap.near",
+					amount: 1000n,
+					destinationAddress: "receiver.near",
+					destinationMemo: "test-memo-123",
+					feeInclusive: false,
+				},
+				feeEstimation: {
+					amount: 0n,
+					quote: null,
+					underlyingFees: { [RouteEnum.InternalTransfer]: null },
+				},
+			});
+
+			expect(intents).toHaveLength(1);
+			expect(intents[0]).toEqual({
+				intent: "transfer",
+				receiver_id: "receiver.near",
+				tokens: { "nep141:wrap.near": "1000" },
+				memo: "test-memo-123",
+			});
+		});
+
+		it("sets memo to undefined when destinationMemo is not provided", async () => {
+			const bridge = new IntentsBridge();
+			const intents = await bridge.createWithdrawalIntents({
+				withdrawalParams: {
+					assetId: "nep141:wrap.near",
+					amount: 500n,
+					destinationAddress: "receiver.near",
+					feeInclusive: false,
+				},
+				feeEstimation: {
+					amount: 0n,
+					quote: null,
+					underlyingFees: { [RouteEnum.InternalTransfer]: null },
+				},
+			});
+
+			expect(intents).toHaveLength(1);
+			expect(intents[0]).toEqual({
+				intent: "transfer",
+				receiver_id: "receiver.near",
+				tokens: { "nep141:wrap.near": "500" },
+				memo: undefined,
+			});
+		});
+	});
+
 	describe("validateWithdrawal()", () => {
 		it.each(["user.near", "aurora", zeroAddress])(
 			"allows EVM and regular addresses",

--- a/packages/intents-sdk/src/bridges/intents-bridge/intents-bridge.ts
+++ b/packages/intents-sdk/src/bridges/intents-bridge/intents-bridge.ts
@@ -46,6 +46,7 @@ export class IntentsBridge implements Bridge {
 					[args.withdrawalParams.assetId]:
 						args.withdrawalParams.amount.toString(),
 				},
+				memo: args.withdrawalParams.destinationMemo,
 			},
 		];
 

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -244,7 +244,10 @@ export interface WithdrawalParams {
 	amount: bigint;
 	destinationAddress: string;
 	/**
-	 * XRP Leger chain specific. MEMO IS NOT SUPPORTED FOR STELLAR AND TON.
+	 * Optional memo attached to the withdrawal.
+	 * - XRP Ledger: included in the transaction memo field
+	 * - Internal transfers (intents): passed as memo in the transfer intent
+	 * - Stellar, TON: NOT SUPPORTED (will throw error)
 	 */
 	destinationMemo?: string | undefined;
 	feeInclusive: boolean;


### PR DESCRIPTION
## Summary
- Pass `destinationMemo` through to the transfer intent's `memo` field when using the InternalTransfer route (intents bridge)
- Update `destinationMemo` JSDoc to document supported routes
- Add tests for memo handling in IntentsBridge

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm biome check` passes  
- [x] New tests in `intents-bridge.test.ts` pass