### PR TITLE
feat(intents-sdk): add signRaw method to signers

### DIFF
--- a/.changeset/add-sign-raw-method.md
+++ b/.changeset/add-sign-raw-method.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Add `signRaw()` method to signers for signing arbitrary payloads (e.g. server-generated challenges)

--- a/packages/intents-sdk/index.ts
+++ b/packages/intents-sdk/index.ts
@@ -13,6 +13,8 @@ export {
 } from "./src/intents/intent-signer-impl/factories";
 
 export type { IIntentSigner } from "./src/intents/interfaces/intent-signer";
+export type { Erc191RawPayload } from "./src/intents/intent-signer-impl/intent-signer-viem";
+export type { Nep413RawPayload } from "./src/intents/intent-signer-impl/intent-signer-nep413";
 
 // ============================================================================
 // Core Types

--- a/packages/intents-sdk/src/intents/intent-signer-impl/factories.ts
+++ b/packages/intents-sdk/src/intents/intent-signer-impl/factories.ts
@@ -1,4 +1,3 @@
-import type { IIntentSigner } from "../interfaces/intent-signer";
 import {
 	IntentSignerNearKeypair,
 	type IntentSignerNearKeypairConfig,
@@ -14,18 +13,18 @@ import {
 
 export function createIntentSignerNEP413(
 	config: IntentSignerNEP413Config,
-): IIntentSigner {
+): IntentSignerNEP413 {
 	return new IntentSignerNEP413(config);
 }
 
 export function createIntentSignerNearKeyPair(
 	config: IntentSignerNearKeypairConfig,
-): IIntentSigner {
+): IntentSignerNearKeypair {
 	return new IntentSignerNearKeypair(config);
 }
 
 export function createIntentSignerViem(
 	config: IntentSignerViemConfig,
-): IIntentSigner {
+): IntentSignerViem {
 	return new IntentSignerViem(config);
 }

--- a/packages/intents-sdk/src/intents/intent-signer-impl/intent-signer-nep413.test.ts
+++ b/packages/intents-sdk/src/intents/intent-signer-impl/intent-signer-nep413.test.ts
@@ -1,0 +1,136 @@
+import { base64 } from "@scure/base";
+import { describe, expect, it, vi } from "vitest";
+import { IntentSignerNEP413 } from "./intent-signer-nep413";
+
+describe("IntentSignerNEP413", () => {
+	const mockPublicKey = "ed25519:6TupyNrcHGTt5XRLmHTc2KGaiSbjhQi1KHtCXTgbcr4Y";
+	const mockSignature = base64.encode(new Uint8Array(64).fill(1));
+
+	const createSigner = () => {
+		const signMessage = vi.fn().mockResolvedValue({
+			publicKey: mockPublicKey,
+			signature: mockSignature,
+		});
+
+		const signer = new IntentSignerNEP413({
+			signMessage,
+			accountId: "test.near",
+		});
+
+		return { signer, signMessage };
+	};
+
+	describe("signRaw()", () => {
+		it("returns MultiPayloadNep413 with correct structure", async () => {
+			const { signer } = createSigner();
+			const nonce = base64.encode(new Uint8Array(32).fill(42));
+
+			const result = await signer.signRaw({
+				payload: {
+					message: "test message",
+					nonce,
+					recipient: "app.near",
+				},
+			});
+
+			expect(result).toMatchObject({
+				standard: "nep413",
+				payload: {
+					message: "test message",
+					nonce,
+					recipient: "app.near",
+				},
+				public_key: mockPublicKey,
+			});
+			expect(result.signature).toMatch(/^ed25519:/);
+		});
+
+		it("calls signMessage with NEP413Payload and hash", async () => {
+			const { signer, signMessage } = createSigner();
+			const nonce = base64.encode(new Uint8Array(32).fill(42));
+
+			await signer.signRaw({
+				payload: {
+					message: "test",
+					nonce,
+					recipient: "app.near",
+				},
+			});
+
+			expect(signMessage).toHaveBeenCalledOnce();
+			// biome-ignore lint/style/noNonNullAssertion: asserted above
+			const [nep413Payload, hash] = signMessage.mock.calls[0]!;
+
+			expect(nep413Payload).toMatchObject({
+				message: "test",
+				recipient: "app.near",
+			});
+			expect(nep413Payload.nonce).toHaveLength(32);
+			expect(hash).toBeInstanceOf(Uint8Array);
+			expect(hash).toHaveLength(32);
+		});
+
+		it("preserves callbackUrl if provided", async () => {
+			const { signer } = createSigner();
+			const nonce = base64.encode(new Uint8Array(32).fill(42));
+
+			const result = await signer.signRaw({
+				payload: {
+					message: "test",
+					nonce,
+					recipient: "app.near",
+					callbackUrl: "https://example.com/callback",
+				},
+			});
+
+			expect(result.payload.callbackUrl).toBe("https://example.com/callback");
+		});
+	});
+
+	describe("signIntent()", () => {
+		it("returns MultiPayloadNep413 with JSON-serialized message", async () => {
+			const { signer } = createSigner();
+			const nonce = base64.encode(new Uint8Array(32).fill(42));
+
+			const result = await signer.signIntent({
+				signer_id: "user.near",
+				verifying_contract: "intents.near",
+				deadline: "2025-01-01T00:00:00.000Z",
+				nonce,
+				intents: [],
+			});
+
+			expect(result.standard).toBe("nep413");
+			expect(result.payload.recipient).toBe("intents.near");
+			expect(result.payload.nonce).toBe(nonce);
+
+			const message = JSON.parse(result.payload.message);
+			expect(message).toEqual({
+				signer_id: "user.near",
+				deadline: "2025-01-01T00:00:00.000Z",
+				intents: [],
+			});
+		});
+
+		it("uses accountId when signer_id not provided", async () => {
+			const { signer } = createSigner();
+			const nonce = base64.encode(new Uint8Array(32).fill(42));
+
+			const result = await signer.signIntent({
+				signer_id: undefined,
+				verifying_contract: "intents.near",
+				deadline: "2025-01-01T00:00:00.000Z",
+				nonce,
+				intents: [],
+			});
+
+			const message = JSON.parse(result.payload.message);
+			expect(message.signer_id).toBe("test.near");
+		});
+	});
+
+	it("has standard property set to nep413", () => {
+		const { signer } = createSigner();
+		expect(signer.standard).toBe("nep413");
+	});
+});

--- a/packages/intents-sdk/src/intents/intent-signer-impl/intent-signer-viem.test.ts
+++ b/packages/intents-sdk/src/intents/intent-signer-impl/intent-signer-viem.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+import { IntentSignerViem } from "./intent-signer-viem";
+
+describe("IntentSignerViem", () => {
+	const account = privateKeyToAccount(generatePrivateKey());
+	const signer = new IntentSignerViem({ signer: account });
+
+	describe("signRaw()", () => {
+		it("returns MultiPayloadErc191 with correct structure", async () => {
+			const result = await signer.signRaw({ payload: "test message" });
+
+			expect(result).toMatchObject({
+				standard: "erc191",
+				payload: "test message",
+			});
+			expect(result.signature).toMatch(/^secp256k1:/);
+		});
+
+		it("preserves payload exactly as provided", async () => {
+			const payload = '{"foo":"bar","nested":{"value":123}}';
+			const result = await signer.signRaw({ payload });
+
+			expect(result.payload).toBe(payload);
+		});
+	});
+
+	describe("signIntent()", () => {
+		it("returns MultiPayloadErc191 with JSON-serialized intent", async () => {
+			const result = await signer.signIntent({
+				signer_id: "test.near",
+				verifying_contract: "intents.near",
+				deadline: "2025-01-01T00:00:00.000Z",
+				nonce: "dGVzdG5vbmNl",
+				intents: [],
+			});
+
+			expect(result.standard).toBe("erc191");
+			expect(result.signature).toMatch(/^secp256k1:/);
+
+			const parsed = JSON.parse(result.payload);
+			expect(parsed).toEqual({
+				signer_id: "test.near",
+				verifying_contract: "intents.near",
+				deadline: "2025-01-01T00:00:00.000Z",
+				nonce: "dGVzdG5vbmNl",
+				intents: [],
+			});
+		});
+	});
+
+	it("has standard property set to erc191", () => {
+		expect(signer.standard).toBe("erc191");
+	});
+});


### PR DESCRIPTION
## Summary
- Add `signRaw()` method to `IntentSignerViem` and `IntentSignerNEP413` for signing arbitrary payloads
- `signIntent()` now uses `signRaw()` under the hood
- Factory functions return concrete types (instead of `IIntentSigner`) for `signRaw` access
- Export `Erc191RawPayload` and `Nep413RawPayload` types

## Usage

```typescript
const signer = createIntentSignerViem({ signer: account });

// Sign arbitrary payload (e.g. server-generated challenge)
const signed = await signer.signRaw({ payload: "challenge-from-server" });

// For intents, use signIntent (uses signRaw internally)
const intentSigned = await signer.signIntent(intentPayload);
```

## Test plan
- [x] Unit tests for `signRaw()` in both signers
- [x] TypeScript types pass