### PR TITLE
fix: point CJS consumers at .d.cts type declarations

### DIFF
--- a/.changeset/cjs-type-exports.md
+++ b/.changeset/cjs-type-exports.md
@@ -1,0 +1,8 @@
+---
+"@defuse-protocol/intents-sdk": patch
+"@defuse-protocol/internal-utils": patch
+"@defuse-protocol/crosschain-assetid": patch
+"@defuse-protocol/contract-types": patch
+---
+
+Point CJS consumers at `.d.cts` type declarations via conditional `exports`. With `"type": "module"` set, every `.d.ts` file is interpreted as ESM-flavored types under `moduleResolution: node16`/`nodenext`/`bundler`, which can cause subtle interop mismatches (e.g. around default exports) for CJS consumers. tsdown already emits the `.d.cts` artifacts; this change wires them into the `exports` map so they actually get resolved.

--- a/packages/contract-types/package.json
+++ b/packages/contract-types/package.json
@@ -18,17 +18,25 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"default": "./dist/index.js"
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		},
 		"./schemas/intents.schema.json": "./schemas/intents.schema.json",
 		"./validate": {
-			"types": "./dist/validate.d.ts",
-			"import": "./dist/validate.js",
-			"require": "./dist/validate.cjs",
-			"default": "./dist/validate.js"
+			"import": {
+				"types": "./dist/validate.d.ts",
+				"default": "./dist/validate.js"
+			},
+			"require": {
+				"types": "./dist/validate.d.cts",
+				"default": "./dist/validate.cjs"
+			}
 		}
 	},
 	"typesVersions": {

--- a/packages/crosschain-assetid/package.json
+++ b/packages/crosschain-assetid/package.json
@@ -18,10 +18,14 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"default": "./dist/index.js"
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		},
 		"./schemas/1cs_v1-object.schema.json": "./schemas/1cs_v1-object.schema.json",
 		"./schemas/1cs_v1-string.schema.json": "./schemas/1cs_v1-string.schema.json"

--- a/packages/intents-sdk/package.json
+++ b/packages/intents-sdk/package.json
@@ -18,10 +18,14 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"default": "./dist/index.js"
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		}
 	},
 	"files": [

--- a/packages/internal-utils/package.json
+++ b/packages/internal-utils/package.json
@@ -18,10 +18,14 @@
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"import": "./dist/index.js",
-			"require": "./dist/index.cjs",
-			"default": "./dist/index.js"
+			"import": {
+				"types": "./dist/index.d.ts",
+				"default": "./dist/index.js"
+			},
+			"require": {
+				"types": "./dist/index.d.cts",
+				"default": "./dist/index.cjs"
+			}
 		}
 	},
 	"files": [


### PR DESCRIPTION
## Summary

- Nest `types` inside the `import`/`require` conditions in each package's `exports` map so CJS consumers resolve to `.d.cts` (not `.d.ts`).
- Affects `intents-sdk`, `internal-utils`, `crosschain-assetid`, and `contract-types` (both root and `./validate` subpath).

## Why

All four packages declare `"type": "module"`. Under TypeScript's `moduleResolution: node16` / `nodenext` / `bundler`, every `.d.ts` is interpreted as an **ESM-flavored** type declaration. CJS consumers were therefore being handed ESM types via the single top-level `types` field, which can cause subtle interop mismatches around default exports and namespace imports.

`tsdown` (`format: ["esm","cjs"], dts: true, unbundle: true`) already emits the matching `.d.cts` artifacts — they were sitting in `dist/` unused. This PR just wires them into the `exports` map.

The top-level `"types"` and `typesVersions` fields are kept as fallbacks for legacy `moduleResolution: "node"` consumers, which don't read conditional exports.

## Test plan

- [x] `pnpm build` succeeds in all four packages
- [x] `pnpm typecheck` passes
- [x] Spot-check `dist/` after build: `index.d.cts` exists for each affected entry point
- [x] Once published, verify a CJS consumer resolves `.d.cts` (e.g. via `tsc --traceResolution` or `@arethetypeswrong/cli`)