### PR TITLE
Split relay publish error states

### DIFF
--- a/.changeset/split-relay-publish-errors.md
+++ b/.changeset/split-relay-publish-errors.md
@@ -1,0 +1,8 @@
+---
+"@defuse-protocol/internal-utils": minor
+"@defuse-protocol/intents-sdk": minor
+---
+
+Split relay publish failures into confirmed rejections and unknown-result errors. `publishIntents` now uses `RelayPublishRejectedError` for relay `status: "FAILED"` responses and `RelayPublishResultUnknownError` when a usable publish response cannot be confirmed, while keeping `RelayPublishError` as the shared base class.
+
+**BREAKING CHANGES:** `RelayPublishError` is now an abstract base class, `code` only exists on `RelayPublishRejectedError`, and `NETWORK_ERROR` is no longer part of the publish rejection code set. Handle `RelayPublishResultUnknownError` for in-doubt publish results.

--- a/packages/intents-sdk/index.ts
+++ b/packages/intents-sdk/index.ts
@@ -173,6 +173,10 @@ export {
 	type IntentSettlementErrorType,
 	RelayPublishError,
 	type RelayPublishErrorType,
+	RelayPublishRejectedError,
+	type RelayPublishRejectedErrorType,
+	RelayPublishResultUnknownError,
+	type RelayPublishResultUnknownErrorType,
 } from "@defuse-protocol/internal-utils";
 
 export type {

--- a/packages/intents-sdk/src/sdk.signAndSendIntent.test.ts
+++ b/packages/intents-sdk/src/sdk.signAndSendIntent.test.ts
@@ -1,6 +1,7 @@
 import {
 	configsByEnvironment,
 	RelayPublishError,
+	RelayPublishRejectedError,
 } from "@defuse-protocol/internal-utils";
 import { privateKeyToAccount } from "viem/accounts";
 import { describe, expect, it, vi } from "vitest";
@@ -66,7 +67,7 @@ describe("sdk.signAndSendIntent()", () => {
 
 		// Fail on any error exept salt error
 		vi.mocked(intentRelayer.publishIntent).mockRejectedValueOnce(
-			new RelayPublishError({
+			new RelayPublishRejectedError({
 				reason: "nonce was already used",
 				code: "NONCE_USED",
 				publishParams: { quote_hashes: [], signed_datas: [] },
@@ -82,7 +83,7 @@ describe("sdk.signAndSendIntent()", () => {
 
 		// Retry on salt error
 		vi.mocked(intentRelayer.publishIntent).mockRejectedValueOnce(
-			new RelayPublishError({
+			new RelayPublishRejectedError({
 				reason: "Invalid salt",
 				code: "INVALID_SALT",
 				publishParams: { quote_hashes: [], signed_datas: [] },

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -8,7 +8,7 @@ import {
 	nearFailoverRpcProvider,
 	extractRpcUrls,
 	solverRelay,
-	RelayPublishError,
+	RelayPublishRejectedError,
 	type RpcEndpoint,
 } from "@defuse-protocol/internal-utils";
 import { HotBridge as hotLabsOmniSdk_HotBridge } from "@hot-labs/omni-sdk";
@@ -677,7 +677,12 @@ export class IntentsSDK implements IIntentsSDK {
 
 			return await fn(cachedSalt);
 		} catch (err) {
-			if (!(err instanceof RelayPublishError && err.code === "INVALID_SALT"))
+			if (
+				!(
+					err instanceof RelayPublishRejectedError &&
+					err.code === "INVALID_SALT"
+				)
+			)
 				throw err;
 
 			args.logger?.warn?.("Salt error detected. Refreshing salt and retrying");

--- a/packages/internal-utils/src/index.ts
+++ b/packages/internal-utils/src/index.ts
@@ -95,6 +95,10 @@ export {
 export {
 	RelayPublishError,
 	type RelayPublishErrorType,
+	RelayPublishRejectedError,
+	type RelayPublishRejectedErrorType,
+	RelayPublishResultUnknownError,
+	type RelayPublishResultUnknownErrorType,
 } from "./solverRelay/utils/parseFailedPublishError";
 
 // Top-level utils

--- a/packages/internal-utils/src/solverRelay/publishIntents.test.ts
+++ b/packages/internal-utils/src/solverRelay/publishIntents.test.ts
@@ -1,16 +1,62 @@
+import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
+import { server } from "../../test/setup";
 import { publishIntents } from "./publishIntents";
-import { RelayPublishError } from "./utils/parseFailedPublishError";
+import type { PublishIntentsResponse } from "./solverRelayHttpClient/types";
+import {
+	RelayPublishError,
+	RelayPublishRejectedError,
+	RelayPublishResultUnknownError,
+} from "./utils/parseFailedPublishError";
 
 describe("publishIntents()", () => {
-	it("should return UNKNOWN_ERROR", async () => {
-		const a = await publishIntents({
+	it("returns rejected error for failed relay publish response", async () => {
+		server.use(
+			http.post("https://solver-relay-v2.chaindefuser.com/rpc", () => {
+				return HttpResponse.json({
+					id: "dontcare",
+					jsonrpc: "2.0",
+					result: {
+						intent_hashes: [],
+						status: "FAILED",
+						reason: "unknown relay failure",
+					},
+				} satisfies PublishIntentsResponse);
+			}),
+		);
+
+		const result = await publishIntents({
 			quote_hashes: [],
 			signed_datas: [],
 		});
 
-		const err = a.unwrapErr();
+		const err = result.unwrapErr();
 		expect(err).toBeInstanceOf(RelayPublishError);
+		expect(err).toBeInstanceOf(RelayPublishRejectedError);
 		expect(err).toHaveProperty("code", "UNKNOWN_ERROR");
+	});
+
+	it("returns result unknown error when publish result cannot be confirmed", async () => {
+		server.use(
+			http.post("https://solver-relay-v2.chaindefuser.com/rpc", () => {
+				return HttpResponse.json({
+					id: "dontcare",
+					jsonrpc: "2.0",
+					error: {
+						code: -32000,
+						message: "relay unavailable",
+					},
+				});
+			}),
+		);
+
+		const result = await publishIntents({
+			quote_hashes: [],
+			signed_datas: [],
+		});
+
+		const err = result.unwrapErr();
+		expect(err).toBeInstanceOf(RelayPublishError);
+		expect(err).toBeInstanceOf(RelayPublishResultUnknownError);
 	});
 });

--- a/packages/internal-utils/src/solverRelay/publishIntents.ts
+++ b/packages/internal-utils/src/solverRelay/publishIntents.ts
@@ -1,7 +1,7 @@
 import { Err, Ok, type Result } from "@thames/monads";
 import * as solverRelayClient from "./solverRelayHttpClient";
 import {
-	RelayPublishError,
+	RelayPublishResultUnknownError,
 	type RelayPublishErrorType,
 	toRelayPublishError,
 } from "./utils/parseFailedPublishError";
@@ -27,9 +27,9 @@ export async function publishIntents(
 				return parsePublishIntentsResponse(params, response);
 			},
 			(err) => {
-				const publishError = new RelayPublishError({
-					reason: "Error occurred during sending a request",
-					code: "NETWORK_ERROR",
+				const publishError = new RelayPublishResultUnknownError({
+					reason:
+						"Failed to receive a usable publish response from the relay. Publish result is unknown.",
 					publishParams: params,
 					cause: err,
 				});

--- a/packages/internal-utils/src/solverRelay/utils/parseFailedPublishError.ts
+++ b/packages/internal-utils/src/solverRelay/utils/parseFailedPublishError.ts
@@ -11,53 +11,107 @@ type PublishErrorCode =
 	| "INSUFFICIENT_BALANCE"
 	| "PUBLIC_KEY_NOT_EXIST"
 	| "UNKNOWN_ERROR"
-	| "NETWORK_ERROR"
 	| "INVALID_SALT";
 
-export type RelayPublishErrorType = RelayPublishError & {
-	name: "RelayPublishError";
+type PublishParams =
+	| Parameters<typeof solverRelayClient.publishIntents>[0]
+	| Parameters<typeof solverRelayClient.publishIntent>[0];
+
+export type RelayPublishRejectedErrorType = RelayPublishRejectedError & {
+	name: "RelayPublishRejectedError";
 };
-export class RelayPublishError extends BaseError {
-	name = "RelayPublishError" as const;
+
+export type RelayPublishResultUnknownErrorType =
+	RelayPublishResultUnknownError & {
+		name: "RelayPublishResultUnknownError";
+	};
+
+export type RelayPublishErrorType =
+	| RelayPublishRejectedErrorType
+	| RelayPublishResultUnknownErrorType;
+
+export abstract class RelayPublishError extends BaseError {
+	publishParams: PublishParams;
+
+	protected constructor({
+		cause,
+		metaMessages,
+		name,
+		publishParams,
+		reason,
+	}: {
+		cause?: unknown;
+		metaMessages?: string[];
+		name: "RelayPublishRejectedError" | "RelayPublishResultUnknownError";
+		publishParams: PublishParams;
+		reason: string;
+	}) {
+		super("Failed to publish intent.", {
+			details: reason,
+			metaMessages: [
+				...(metaMessages ?? []),
+				`Publish params: ${serialize(publishParams)}`,
+			],
+			name,
+			cause,
+		});
+		this.publishParams = publishParams;
+	}
+}
+
+export class RelayPublishRejectedError extends RelayPublishError {
+	name = "RelayPublishRejectedError" as const;
 	code: PublishErrorCode;
 
 	constructor({
 		reason,
 		code,
 		publishParams,
-		cause,
 	}: {
 		reason: string;
 		code: PublishErrorCode;
-		publishParams:
-			| Parameters<typeof solverRelayClient.publishIntents>[0]
-			| Parameters<typeof solverRelayClient.publishIntent>[0];
-		cause?: unknown;
+		publishParams: PublishParams;
 	}) {
-		super("Failed to publish intent.", {
-			details: reason,
-			metaMessages: [
-				`Code: ${code}`,
-				`Publish params: ${serialize(publishParams)}`,
-			],
-			name: "RelayPublishError",
-			cause: cause,
+		super({
+			reason,
+			metaMessages: [`Code: ${code}`],
+			name: "RelayPublishRejectedError",
+			publishParams,
 		});
 		this.code = code;
 	}
 }
 
+export class RelayPublishResultUnknownError extends RelayPublishError {
+	name = "RelayPublishResultUnknownError" as const;
+
+	constructor({
+		reason,
+		publishParams,
+		cause,
+	}: {
+		reason: string;
+		publishParams: PublishParams;
+		cause?: unknown;
+	}) {
+		super({
+			reason,
+			name: "RelayPublishResultUnknownError",
+			publishParams,
+			cause,
+		});
+	}
+}
+
 export function toRelayPublishError(
-	publishParams:
-		| Parameters<typeof solverRelayClient.publishIntents>[0]
-		| Parameters<typeof solverRelayClient.publishIntent>[0],
+	publishParams: PublishParams,
 	response:
 		| Awaited<ReturnType<typeof solverRelayClient.publishIntents>>
 		| Awaited<ReturnType<typeof solverRelayClient.publishIntent>>,
-): RelayPublishErrorType {
+): RelayPublishRejectedErrorType {
 	assert(response.status === "FAILED", "Expected response to be failed");
 
-	return new RelayPublishError({
+	return new RelayPublishRejectedError({
 		reason: response.reason,
 		code: parseFailedPublishReason(response),
 		publishParams,


### PR DESCRIPTION
Relay publish failures can leave callers with two very different recovery paths: confirmed rejection is terminal, while a missing or unusable response is in doubt and may require status lookup or careful retry. This makes that boundary explicit so SDK consumers do not have to infer transaction state from NETWORK_ERROR.