### PR TITLE
fix: prefer indexed TON withdrawal hashes

### DIFF
--- a/.changeset/ton-hot-indexer-hash.md
+++ b/.changeset/ton-hot-indexer-hash.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": patch
+---
+
+Use bridge-indexer as the source of truth for TON HOT withdrawal destination transaction hashes.

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
@@ -1,5 +1,8 @@
-import { configsByEnvironment } from "@defuse-protocol/internal-utils";
-import { describe, expect, it, vi } from "vitest";
+import {
+	bridgeIndexer,
+	configsByEnvironment,
+} from "@defuse-protocol/internal-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HotBridge } from "./hot-bridge";
 import {
 	InvalidDestinationAddressForWithdrawalError,
@@ -26,7 +29,84 @@ import { HotBridgeEVMChains } from "./hot-bridge-chains";
 import type { IntentPrimitive } from "../../intents/shared-types";
 import { RouteEnum } from "../../constants/route-enum";
 import type { FeeEstimation } from "../../shared-types";
+
+vi.mock("@defuse-protocol/internal-utils", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@defuse-protocol/internal-utils")>();
+
+	return {
+		...actual,
+		bridgeIndexer: {
+			...actual.bridgeIndexer,
+			httpClient: {
+				...actual.bridgeIndexer.httpClient,
+				withdrawalsByNearTxHash: vi.fn(),
+			},
+		},
+	};
+});
+
+type BridgeIndexerResponse = Awaited<
+	ReturnType<typeof bridgeIndexer.httpClient.withdrawalsByNearTxHash>
+>;
+
+const TON_USDT_ASSET_ID =
+	"nep245:v2_1.omni.hot.tg:1117_3tsdfyziyc7EJbP2aULWSKU4toBaAcN4FdTgfm5W1mC4ouR";
+const BNB_NATIVE_ASSET_ID = "nep245:v2_1.omni.hot.tg:56_11111111111111111111";
+const TON_DESTINATION_ADDRESS =
+	"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI";
+
+function bridgeIndexerResponse(
+	withdrawals: BridgeIndexerResponse["withdrawals"],
+): BridgeIndexerResponse {
+	return {
+		near_trx: "near-tx-hash",
+		withdrawals,
+	};
+}
+
+function bridgeIndexerWithdrawal({
+	hash,
+	nonce = "1",
+}: {
+	hash: string | null;
+	nonce?: string;
+}): BridgeIndexerResponse["withdrawals"][number] {
+	return {
+		hash,
+		nonce,
+		chain_id: 1117,
+		withdraw_asset: null,
+		withdraw_token: null,
+		withdraw_amount: null,
+		receiver_address: TON_DESTINATION_ADDRESS,
+		signature: null,
+		near_tx_time: null,
+		near_tx_block: null,
+		destination_chain_block: null,
+	};
+}
+
+function mockBridgeIndexerWithdrawals(
+	withdrawals: BridgeIndexerResponse["withdrawals"],
+): void {
+	vi.mocked(bridgeIndexer.httpClient.withdrawalsByNearTxHash).mockResolvedValue(
+		bridgeIndexerResponse(withdrawals),
+	);
+}
+
+function mockBridgeIndexerFailure(): void {
+	vi.mocked(bridgeIndexer.httpClient.withdrawalsByNearTxHash).mockRejectedValue(
+		new Error("Bridge indexer error"),
+	);
+}
+
 describe("HotBridge", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.mocked(bridgeIndexer.httpClient.withdrawalsByNearTxHash).mockReset();
+	});
+
 	describe("supports()", () => {
 		it.each([
 			"nep245:v2_1.omni.hot.tg:56_11111111111111111111",
@@ -249,7 +329,53 @@ describe("HotBridge", () => {
 	});
 
 	describe("describeWithdrawal()", () => {
-		it("returns completed status with destination tx hash", async () => {
+		it("returns completed TON status with bridge indexer hash", async () => {
+			const hotSDK = new HotOmniSdk({
+				logger: console,
+				evmRpc: {},
+				nearRpc: [],
+				async executeNearTransaction() {
+					throw new Error("not implemented");
+				},
+			});
+
+			const bridge = new HotBridge({
+				envConfig: configsByEnvironment.production,
+				hotSdk: hotSDK,
+			});
+
+			const hotTraceRootHash =
+				"4a810b9459ce2e73d74b497598744e3cb54f50715f90ef07a66397468a60b121";
+			const receiverJettonWalletHash =
+				"2dbebb2ab0d2ad52ed026fc23e3a23c92e1ca23ae5355a4f99dc8f2fc97ff1c1";
+			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
+			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(
+				hotTraceRootHash,
+			);
+			mockBridgeIndexerWithdrawals([
+				bridgeIndexerWithdrawal({ hash: receiverJettonWalletHash }),
+			]);
+
+			const wid = bridge.createWithdrawalIdentifier({
+				withdrawalParams: {
+					assetId: TON_USDT_ASSET_ID,
+					amount: 100n,
+					destinationAddress: TON_DESTINATION_ADDRESS,
+					feeInclusive: false,
+				},
+				index: 0,
+				tx: { hash: "near-tx-hash", accountId: "test.near" },
+			});
+
+			const result = await bridge.describeWithdrawal(wid);
+
+			expect(result).toEqual({
+				status: "completed",
+				txHash: receiverJettonWalletHash,
+			});
+		});
+
+		it("keeps TON withdrawal pending while bridge indexer has no hash", async () => {
 			const hotSDK = new HotOmniSdk({
 				logger: console,
 				evmRpc: {},
@@ -266,27 +392,83 @@ describe("HotBridge", () => {
 
 			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(
-				"DEADBEEF",
+				"4a810b9459ce2e73d74b497598744e3cb54f50715f90ef07a66397468a60b121",
 			);
+			mockBridgeIndexerWithdrawals([]);
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
-					assetId: "nep245:v2_1.omni.hot.tg:1117_",
+					assetId: TON_USDT_ASSET_ID,
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: TON_DESTINATION_ADDRESS,
 					feeInclusive: false,
 				},
 				index: 0,
-				tx: { hash: "", accountId: "" },
+				tx: { hash: "near-tx-hash", accountId: "test.near" },
 			});
 
 			const result = await bridge.describeWithdrawal(wid);
 
-			expect(result).toEqual({ status: "completed", txHash: "DEADBEEF" });
+			expect(result).toEqual({ status: "pending" });
 		});
 
-		it("returns completed status with null hash if destination tx hash is not valid", async () => {
+		it("keeps TON withdrawal pending when bridge indexer request fails", async () => {
+			const hotSDK = new HotOmniSdk({
+				logger: console,
+				evmRpc: {},
+				nearRpc: [],
+				async executeNearTransaction() {
+					throw new Error("not implemented");
+				},
+			});
+
+			const bridge = new HotBridge({
+				envConfig: configsByEnvironment.production,
+				hotSdk: hotSDK,
+			});
+
+			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
+			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(null);
+			mockBridgeIndexerFailure();
+			const requestApiSpy = vi
+				.spyOn(hotSDK.api, "requestApi")
+				.mockResolvedValue(
+					new Response(
+						JSON.stringify({
+							hash: "4a810b9459ce2e73d74b497598744e3cb54f50715f90ef07a66397468a60b121",
+							nonce: "1",
+							near_trx: "near-tx-hash",
+							withdrawals: [
+								{
+									hash: "4a810b9459ce2e73d74b497598744e3cb54f50715f90ef07a66397468a60b121",
+									nonce: "1",
+									near_trx: "near-tx-hash",
+									verified_withdraw: true,
+									chain_id: 1117,
+								},
+							],
+						}),
+					),
+				);
+
+			const wid = bridge.createWithdrawalIdentifier({
+				withdrawalParams: {
+					assetId: TON_USDT_ASSET_ID,
+					amount: 100n,
+					destinationAddress: TON_DESTINATION_ADDRESS,
+					feeInclusive: false,
+				},
+				index: 0,
+				tx: { hash: "near-tx-hash", accountId: "test.near" },
+			});
+
+			const result = await bridge.describeWithdrawal(wid);
+
+			expect(result).toEqual({ status: "pending" });
+			expect(requestApiSpy).not.toHaveBeenCalled();
+		});
+
+		it("keeps TON withdrawal pending when bridge indexer has no hash and HOT status hash is invalid", async () => {
 			const hotSDK = new HotOmniSdk({
 				logger: console,
 				evmRpc: {},
@@ -305,14 +487,7 @@ describe("HotBridge", () => {
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(
 				"invalid_tx_hash",
 			);
-
-			const mockLogger = {
-				error() {},
-				warn: vi.fn(),
-				info() {},
-				debug() {},
-				trace() {},
-			};
+			mockBridgeIndexerWithdrawals([]);
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
@@ -327,16 +502,9 @@ describe("HotBridge", () => {
 				tx: { hash: "", accountId: "" },
 			});
 
-			const result = await bridge.describeWithdrawal({
-				...wid,
-				logger: mockLogger,
-			});
+			const result = await bridge.describeWithdrawal(wid);
 
-			expect(result).toEqual({ status: "completed", txHash: null });
-			expect(mockLogger.warn).toHaveBeenCalledWith(
-				"HOT Bridge incorrect destination tx hash detected",
-				{ value: "invalid_tx_hash" },
-			);
+			expect(result).toEqual({ status: "pending" });
 		});
 
 		it("returns failed status when withdrawal is canceled", async () => {
@@ -363,8 +531,7 @@ describe("HotBridge", () => {
 				withdrawalParams: {
 					assetId: "nep245:v2_1.omni.hot.tg:1117_",
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: TON_DESTINATION_ADDRESS,
 					feeInclusive: false,
 				},
 				index: 0,
@@ -379,7 +546,7 @@ describe("HotBridge", () => {
 			});
 		});
 
-		it("returns completed status with null txHash when status is Completed", async () => {
+		it("keeps TON withdrawal pending when bridge indexer has no hash and HOT status is completed", async () => {
 			const hotSDK = new HotOmniSdk({
 				logger: console,
 				evmRpc: {},
@@ -398,13 +565,13 @@ describe("HotBridge", () => {
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(
 				HotWithdrawStatus.Completed,
 			);
+			mockBridgeIndexerWithdrawals([]);
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
 					assetId: "nep245:v2_1.omni.hot.tg:1117_",
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: TON_DESTINATION_ADDRESS,
 					feeInclusive: false,
 				},
 				index: 0,
@@ -413,7 +580,7 @@ describe("HotBridge", () => {
 
 			const result = await bridge.describeWithdrawal(wid);
 
-			expect(result).toEqual({ status: "completed", txHash: null });
+			expect(result).toEqual({ status: "pending" });
 		});
 
 		it("returns pending status when contract returns null and API has no hash", async () => {
@@ -433,6 +600,7 @@ describe("HotBridge", () => {
 
 			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(null);
+			mockBridgeIndexerFailure();
 			vi.spyOn(hotSDK.api, "requestApi").mockResolvedValue(
 				new Response(
 					JSON.stringify({
@@ -446,10 +614,9 @@ describe("HotBridge", () => {
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
-					assetId: "nep245:v2_1.omni.hot.tg:1117_",
+					assetId: BNB_NATIVE_ASSET_ID,
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: zeroAddress,
 					feeInclusive: false,
 				},
 				index: 0,
@@ -478,6 +645,7 @@ describe("HotBridge", () => {
 
 			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(null);
+			mockBridgeIndexerFailure();
 			vi.spyOn(hotSDK.api, "requestApi").mockResolvedValue(
 				new Response(
 					JSON.stringify({
@@ -490,7 +658,7 @@ describe("HotBridge", () => {
 								nonce: "1",
 								near_trx: "txhash",
 								verified_withdraw: true,
-								chain_id: 1117,
+								chain_id: 56,
 							},
 						],
 					}),
@@ -499,10 +667,9 @@ describe("HotBridge", () => {
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
-					assetId: "nep245:v2_1.omni.hot.tg:1117_",
+					assetId: BNB_NATIVE_ASSET_ID,
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: zeroAddress,
 					feeInclusive: false,
 				},
 				index: 0,
@@ -511,7 +678,7 @@ describe("HotBridge", () => {
 
 			const result = await bridge.describeWithdrawal(wid);
 
-			expect(result).toEqual({ status: "completed", txHash: "DEADBEEF" });
+			expect(result).toEqual({ status: "completed", txHash: "0xDEADBEEF" });
 		});
 
 		it("returns pending when API request fails", async () => {
@@ -531,16 +698,16 @@ describe("HotBridge", () => {
 
 			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(null);
+			mockBridgeIndexerFailure();
 			vi.spyOn(hotSDK.api, "requestApi").mockRejectedValue(
 				new Error("Network error"),
 			);
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
-					assetId: "nep245:v2_1.omni.hot.tg:1117_",
+					assetId: BNB_NATIVE_ASSET_ID,
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: zeroAddress,
 					feeInclusive: false,
 				},
 				index: 0,
@@ -569,6 +736,7 @@ describe("HotBridge", () => {
 
 			vi.spyOn(hotSDK.near, "parseWithdrawalNonces").mockResolvedValue([1n]);
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(null);
+			mockBridgeIndexerFailure();
 			vi.spyOn(hotSDK.api, "requestApi").mockResolvedValue(
 				new Response(
 					JSON.stringify({
@@ -581,7 +749,7 @@ describe("HotBridge", () => {
 								nonce: "1",
 								near_trx: "txhash",
 								verified_withdraw: true,
-								chain_id: 1117,
+								chain_id: 56,
 							},
 						],
 					}),
@@ -590,10 +758,9 @@ describe("HotBridge", () => {
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {
-					assetId: "nep245:v2_1.omni.hot.tg:1117_",
+					assetId: BNB_NATIVE_ASSET_ID,
 					amount: 100n,
-					destinationAddress:
-						"UQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI",
+					destinationAddress: zeroAddress,
 					feeInclusive: false,
 				},
 				index: 0,
@@ -626,6 +793,9 @@ describe("HotBridge", () => {
 			vi.spyOn(hotSDK, "getGaslessWithdrawStatus").mockResolvedValue(
 				"DEADBEEF",
 			);
+			mockBridgeIndexerWithdrawals([
+				bridgeIndexerWithdrawal({ hash: "DEADBEEF" }),
+			]);
 
 			const wid = bridge.createWithdrawalIdentifier({
 				withdrawalParams: {

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts
@@ -390,9 +390,10 @@ export class HotBridge implements Bridge {
 		}
 
 		const isEvm = args.landingChain.startsWith("eip155:");
-		// For EVM networks and Stellar, the bridge indexer is the source of truth for withdrawal hashes.
-		// The HOT API is only used as a fallback since the contract view method can return invalid hashes.
-		if (isEvm || args.landingChain === Chains.Stellar) {
+		const isTon = args.landingChain === Chains.TON;
+		// Bridge indexer is the source of truth for destination hashes on these chains.
+		// TON does not fall back to HOT API hashes because they can refer to trace roots instead of CEX-visible transfers.
+		if (isEvm || args.landingChain === Chains.Stellar || isTon) {
 			try {
 				args.logger?.info("Fetching withdrawal hash from bridge indexer", {
 					nearTxHash: args.tx.hash,
@@ -415,6 +416,18 @@ export class HotBridge implements Bridge {
 					};
 				}
 			} catch (error) {
+				if (isTon) {
+					args.logger?.error(
+						"Bridge indexer failed unexpectedly, keeping TON withdrawal pending",
+						{
+							nearTxHash: args.tx.hash,
+							nonce: nonce.toString(),
+							error,
+						},
+					);
+					return { status: "pending" };
+				}
+
 				// Bridge indexer failed, fallback to HOT API
 				args.logger?.error(
 					"Bridge indexer failed unexpectedly, trying HOT API fallback",


### PR DESCRIPTION
## Problem

For TON withdrawals, the SDK could return a hash that is not the recipient-visible transfer hash. Downstream consumers that rely on the destination transaction hash can then observe a mismatch even though the withdrawal completed.

## Solution

- Prefer the bridge-indexer withdrawal hash for TON, matching the existing indexed-chain flow.
- Keep TON withdrawals pending when the indexer has no usable hash or the indexer request fails, instead of falling back to a potentially different HOT API hash.
- Preserve existing fallback behavior for non-TON chains.
- Add focused unit coverage for TON indexer hashes, missing hashes, indexer failures, and existing fallback behavior.
- Add a patch changeset for `@defuse-protocol/intents-sdk`.

## Validation

- `pnpm test -- run packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts`
- `pnpm --filter @defuse-protocol/intents-sdk typecheck`
- `pnpm biome check packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts .changeset/ton-hot-indexer-hash.md`
- `git diff --check`
- `pnpm build`
