### PR TITLE
Verify quote tokens and fixed amount match the request

### DIFF
--- a/.changeset/verify-quote-tokens.md
+++ b/.changeset/verify-quote-tokens.md
@@ -2,4 +2,4 @@
 "@defuse-protocol/internal-utils": patch
 ---
 
-Drop quotes whose returned tokens don't match the requested tokens
+Drop quotes whose returned tokens or fixed amount don't match the request

--- a/.changeset/verify-quote-tokens.md
+++ b/.changeset/verify-quote-tokens.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/internal-utils": patch
+---
+
+Drop quotes whose returned tokens don't match the requested tokens

--- a/packages/internal-utils/src/solverRelay/getQuote.test.ts
+++ b/packages/internal-utils/src/solverRelay/getQuote.test.ts
@@ -97,10 +97,10 @@ describe("getQuote() exact_amount validation", () => {
 	});
 });
 
-describe("getQuote() returned-token verification", () => {
-	const mismatchedQuote: Quote = {
+describe("getQuote() request verification", () => {
+	const mismatchedTokenQuote: Quote = {
 		...validQuote,
-		quote_hash: "hash-mismatch",
+		quote_hash: "hash-mismatch-token",
 		// Solver echoed back a different output token than requested,
 		// while offering a more attractive amount_out.
 		defuse_asset_identifier_out: "nep245:v2_1.omni.hot.tg:56_other_token",
@@ -109,7 +109,7 @@ describe("getQuote() returned-token verification", () => {
 
 	it("ignores a higher-ranked quote whose tokens differ from the request", async () => {
 		vi.mocked(quoteWithLogModule.quoteWithLog).mockResolvedValueOnce([
-			mismatchedQuote,
+			mismatchedTokenQuote,
 			validQuote,
 		]);
 
@@ -121,9 +121,30 @@ describe("getQuote() returned-token verification", () => {
 		expect(result).toEqual(validQuote);
 	});
 
-	it("throws QuoteError when every quote has mismatched tokens", async () => {
+	it("ignores an exact_in quote whose amount_in differs from the request", async () => {
+		// Solver only fills half the requested input but advertises a huge output.
+		const wrongAmountInQuote: Quote = {
+			...validQuote,
+			quote_hash: "hash-wrong-amount-in",
+			amount_in: "500000000000",
+			amount_out: "99000000000000",
+		};
 		vi.mocked(quoteWithLogModule.quoteWithLog).mockResolvedValueOnce([
-			mismatchedQuote,
+			wrongAmountInQuote,
+			validQuote,
+		]);
+
+		const result = await getQuote({
+			quoteParams: { ...baseParams, exact_amount_in: "1000000000000" },
+			config,
+		});
+
+		expect(result).toEqual(validQuote);
+	});
+
+	it("throws QuoteError when every quote fails to match the request", async () => {
+		vi.mocked(quoteWithLogModule.quoteWithLog).mockResolvedValueOnce([
+			mismatchedTokenQuote,
 		]);
 
 		const error = await getQuote({

--- a/packages/internal-utils/src/solverRelay/getQuote.test.ts
+++ b/packages/internal-utils/src/solverRelay/getQuote.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { AssertionError } from "../errors/assert";
+import { QuoteError } from "./errors/quote";
 import { getQuote } from "./getQuote";
 import type { Quote } from "./solverRelayHttpClient/types";
 import * as quoteWithLogModule from "./utils/quoteWithLog";
@@ -93,5 +94,43 @@ describe("getQuote() exact_amount validation", () => {
 		expect(error.message).toContain(
 			"exact_amount_in=undefined, exact_amount_out=undefined",
 		);
+	});
+});
+
+describe("getQuote() returned-token verification", () => {
+	const mismatchedQuote: Quote = {
+		...validQuote,
+		quote_hash: "hash-mismatch",
+		// Solver echoed back a different output token than requested,
+		// while offering a more attractive amount_out.
+		defuse_asset_identifier_out: "nep245:v2_1.omni.hot.tg:56_other_token",
+		amount_out: "99000000000000",
+	};
+
+	it("ignores a higher-ranked quote whose tokens differ from the request", async () => {
+		vi.mocked(quoteWithLogModule.quoteWithLog).mockResolvedValueOnce([
+			mismatchedQuote,
+			validQuote,
+		]);
+
+		const result = await getQuote({
+			quoteParams: { ...baseParams, exact_amount_in: "1000000000000" },
+			config,
+		});
+
+		expect(result).toEqual(validQuote);
+	});
+
+	it("throws QuoteError when every quote has mismatched tokens", async () => {
+		vi.mocked(quoteWithLogModule.quoteWithLog).mockResolvedValueOnce([
+			mismatchedQuote,
+		]);
+
+		const error = await getQuote({
+			quoteParams: { ...baseParams, exact_amount_in: "1000000000000" },
+			config,
+		}).catch((e) => e);
+
+		expect(error).toBeInstanceOf(QuoteError);
 	});
 });

--- a/packages/internal-utils/src/solverRelay/getQuote.ts
+++ b/packages/internal-utils/src/solverRelay/getQuote.ts
@@ -41,6 +41,14 @@ function handleQuoteResult(
 		});
 	}
 
+	const hasExactIn = quoteParams.exact_amount_in != null;
+	const hasExactOut = quoteParams.exact_amount_out != null;
+	assert(
+		hasExactIn !== hasExactOut,
+		`Invalid quoteParams: exactly one of exact_amount_in or exact_amount_out must be set (got exact_amount_in=${quoteParams.exact_amount_in}, exact_amount_out=${quoteParams.exact_amount_out}).`,
+	);
+	const quoteKind = hasExactIn ? "exact_in" : "exact_out";
+
 	const failedQuotes: FailedQuote[] = [];
 	const validQuotes: Quote[] = [];
 	for (const q of result) {
@@ -50,11 +58,13 @@ function handleQuoteResult(
 		}
 
 		// The relay aggregates quotes from independent solvers, so a buggy or
-		// malicious solver can echo back tokens we never requested. Acting on
-		// such a quote would make the user swap the wrong assets, so drop it
-		// (it is neither a usable quote nor an INSUFFICIENT_AMOUNT failure).
-		if (!matchesRequestedTokens(q, quoteParams)) {
-			logger?.warn("quote: dropping quote with mismatched tokens", {
+		// malicious solver can return a quote that doesn't match what we asked
+		// for: wrong tokens, or a different fixed amount than requested. Acting
+		// on such a quote would make the user swap the wrong assets/amounts, and
+		// a mismatched fixed amount also makes sortQuotes compare unlike quotes.
+		// Drop it (it is neither usable nor an INSUFFICIENT_AMOUNT failure).
+		if (!matchesRequest(q, quoteParams)) {
+			logger?.warn("quote: dropping quote that doesn't match the request", {
 				quoteParams,
 				quote: q,
 			});
@@ -64,13 +74,6 @@ function handleQuoteResult(
 		validQuotes.push(q);
 	}
 
-	const hasExactIn = quoteParams.exact_amount_in != null;
-	const hasExactOut = quoteParams.exact_amount_out != null;
-	assert(
-		hasExactIn !== hasExactOut,
-		`Invalid quoteParams: exactly one of exact_amount_in or exact_amount_out must be set (got exact_amount_in=${quoteParams.exact_amount_in}, exact_amount_out=${quoteParams.exact_amount_out}).`,
-	);
-	const quoteKind = hasExactIn ? "exact_in" : "exact_out";
 	const bestQuote = sortQuotes(validQuotes, quoteKind)[0];
 	if (bestQuote != null) {
 		return bestQuote;
@@ -113,14 +116,24 @@ function isValidQuote(quote: Quote | FailedQuote): quote is Quote {
 	return !("type" in quote);
 }
 
-function matchesRequestedTokens(
+function matchesRequest(
 	quote: Quote,
 	quoteParams: GetQuoteParams["quoteParams"],
 ): boolean {
-	return (
-		quote.defuse_asset_identifier_in ===
-			quoteParams.defuse_asset_identifier_in &&
-		quote.defuse_asset_identifier_out ===
+	if (
+		quote.defuse_asset_identifier_in !==
+			quoteParams.defuse_asset_identifier_in ||
+		quote.defuse_asset_identifier_out !==
 			quoteParams.defuse_asset_identifier_out
-	);
+	) {
+		return false;
+	}
+
+	// Only the side fixed by the request is verified; the other side is what the
+	// solver competes on (max amount_out for exact_in, min amount_in for
+	// exact_out). Compare as BigInt so formatting differences don't matter.
+	if (quoteParams.exact_amount_in != null) {
+		return BigInt(quote.amount_in) === BigInt(quoteParams.exact_amount_in);
+	}
+	return BigInt(quote.amount_out) === BigInt(quoteParams.exact_amount_out);
 }

--- a/packages/internal-utils/src/solverRelay/getQuote.ts
+++ b/packages/internal-utils/src/solverRelay/getQuote.ts
@@ -1,3 +1,4 @@
+import type { ILogger } from "../logger";
 import { assert } from "../utils/assert";
 import { QuoteError } from "./errors/quote";
 import type { quote } from "./solverRelayHttpClient";
@@ -25,12 +26,13 @@ export async function getQuote(
 		timeout: (params.quoteParams?.wait_ms ?? 0) + 10000,
 		...params.config,
 	});
-	return handleQuoteResult(result, params.quoteParams);
+	return handleQuoteResult(result, params.quoteParams, params.config.logger);
 }
 
 function handleQuoteResult(
 	result: Awaited<ReturnType<typeof quote>>,
 	quoteParams: GetQuoteParams["quoteParams"],
+	logger?: ILogger,
 ) {
 	if (result == null) {
 		throw new QuoteError({
@@ -40,13 +42,26 @@ function handleQuoteResult(
 	}
 
 	const failedQuotes: FailedQuote[] = [];
-	const validQuotes = [];
+	const validQuotes: Quote[] = [];
 	for (const q of result) {
-		if (isValidQuote(q)) {
-			validQuotes.push(q);
-		} else {
+		if (!isValidQuote(q)) {
 			failedQuotes.push(q);
+			continue;
 		}
+
+		// The relay aggregates quotes from independent solvers, so a buggy or
+		// malicious solver can echo back tokens we never requested. Acting on
+		// such a quote would make the user swap the wrong assets, so drop it
+		// (it is neither a usable quote nor an INSUFFICIENT_AMOUNT failure).
+		if (!matchesRequestedTokens(q, quoteParams)) {
+			logger?.warn("quote: dropping quote with mismatched tokens", {
+				quoteParams,
+				quote: q,
+			});
+			continue;
+		}
+
+		validQuotes.push(q);
 	}
 
 	const hasExactIn = quoteParams.exact_amount_in != null;
@@ -96,4 +111,16 @@ function sortQuotes(
 
 function isValidQuote(quote: Quote | FailedQuote): quote is Quote {
 	return !("type" in quote);
+}
+
+function matchesRequestedTokens(
+	quote: Quote,
+	quoteParams: GetQuoteParams["quoteParams"],
+): boolean {
+	return (
+		quote.defuse_asset_identifier_in ===
+			quoteParams.defuse_asset_identifier_in &&
+		quote.defuse_asset_identifier_out ===
+			quoteParams.defuse_asset_identifier_out
+	);
 }


### PR DESCRIPTION
The relay aggregates quotes from independent solvers, but `getQuote` never checked the returned quote matched what we asked for. A solver returning the wrong tokens — or the wrong **fixed amount** (the pinned side: `amount_in` for exact_in, `amount_out` for exact_out) — with a high competing amount would be ranked best and handed to the user.

Now drop any quote whose tokens or fixed amount differ from the request (logged as a warning). Only the fixed side is checked; the competing side is what solvers legitimately vary.