### PR TITLE
fix(internal-utils): parse P-256 WebAuthn signatures via @noble/curves, drop @peculiar/asn1

### DIFF
--- a/.changeset/heavy-donuts-repair.md
+++ b/.changeset/heavy-donuts-repair.md
@@ -1,0 +1,9 @@
+---
+"@defuse-protocol/internal-utils": patch
+---
+
+Parse P-256 WebAuthn signatures with `@noble/curves` instead of `@peculiar/asn1-ecc`/`@peculiar/asn1-schema`, and drop both dependencies.
+
+`@peculiar/asn1-schema` keeps decorator-registered schema metadata in a module-singleton registry. When a dependency tree contains two copies of the package, `AsnParser.parse` reads from a different registry than the one `ECDSASigValue` registered in, silently returning empty `r`/`s` — the extracted signature collapses to zero bytes and every ES256 passkey signature fails downstream. `p256.Signature.fromDER(...).normalizeS().toCompactRawBytes()` is behavior-equivalent (DER sign-byte stripping, 32-byte left-padding, low-S normalization) with no global state.
+
+Note: `fromDER` is strict about canonical DER, which spec-compliant authenticators always emit; malformed input now throws instead of being parsed leniently. The unexported-from-index `normalizeSignatureS` helper was removed along with the hand-rolled padding helpers.

--- a/packages/internal-utils/package.json
+++ b/packages/internal-utils/package.json
@@ -42,9 +42,8 @@
 	"dependencies": {
 		"@defuse-protocol/contract-types": "workspace:*",
 		"@lifeomic/attempt": "^3.0.0",
+		"@noble/curves": "^1.4.0",
 		"@noble/hashes": "^1.7.1",
-		"@peculiar/asn1-ecc": "^2.0.0",
-		"@peculiar/asn1-schema": "^2.0.0",
 		"@scure/base": "^1.0.0",
 		"@thames/monads": "^0.7.0",
 		"near-api-js": "^4.0.0 || ^5.0.0",

--- a/packages/internal-utils/src/utils/webAuthn.test.ts
+++ b/packages/internal-utils/src/utils/webAuthn.test.ts
@@ -54,4 +54,19 @@ describe("extractRawSignature()", () => {
 		const result = extractRawSignature(Buffer.from(input, "hex"), "p256");
 		expect(result.length).toBe(64);
 	});
+
+	it("rejects non-canonical DER for p256", () => {
+		// Spurious 0x00 sign byte on an s whose high bit is clear. WebAuthn
+		// authenticators must emit canonical DER, so this is parser strictness
+		// we want to keep: lenient parsing is what masked the duplicate
+		// @peculiar/asn1-schema breakage this module migrated away from.
+		const input =
+			"30450220" +
+			"0b858e8d13abdf3ed76bf3cf952d334010ed758e215d1db07d3a33e637d6caf1" +
+			"022100" +
+			"51571f169a8ee96d083be9d13a12cf81923d6f3df87023ee5f3aa84f807af84a";
+		expect(() =>
+			extractRawSignature(Buffer.from(input, "hex"), "p256"),
+		).toThrow();
+	});
 });

--- a/packages/internal-utils/src/utils/webAuthn.ts
+++ b/packages/internal-utils/src/utils/webAuthn.ts
@@ -1,6 +1,5 @@
-import { ECDSASigValue } from "@peculiar/asn1-ecc";
-import { AsnParser } from "@peculiar/asn1-schema";
-import { base58, hex } from "@scure/base";
+import { p256 } from "@noble/curves/p256";
+import { base58 } from "@scure/base";
 import { base64urlnopad } from "@scure/base";
 import tweetnacl from "tweetnacl";
 import type { CredentialKey, CurveType } from "../types/webAuthn";
@@ -197,73 +196,15 @@ export function extractRawSignature(
 			// https://www.w3.org/TR/webauthn-3/#sctn-signature-attestation-types
 			// For COSEAlgorithmIdentifier -7 (ES256) and other ECDSA-based algorithms,
 			// the signature value MUST be encoded as an ASN.1 DER Ecdsa-Sig-Value.
-			const parsedSignature = AsnParser.parse(
-				attestationSignature,
-				ECDSASigValue,
-			);
-			let rBytes: Uint8Array = new Uint8Array(parsedSignature.r);
-			let sBytes: Uint8Array = new Uint8Array(parsedSignature.s);
-
-			if (shouldRemoveLeadingZero(rBytes)) {
-				rBytes = rBytes.slice(1);
-			}
-			if (shouldRemoveLeadingZero(sBytes)) {
-				sBytes = sBytes.slice(1);
-			}
-
-			sBytes = normalizeSignatureS(sBytes);
-
-			// Left-pad r and s to 32 bytes each (P-256 fixed-width format).
-			// DER encoding strips leading zeros, so after parsing the components
-			// may be shorter than 32 bytes (~0.4% chance per component).
-			rBytes = padToLength(rBytes, 32);
-			sBytes = padToLength(sBytes, 32);
-
-			return concatUint8Arrays([rBytes, sBytes]);
+			// `fromDER` handles DER sign-byte stripping; `toCompactRawBytes` left-pads
+			// r and s to 32 bytes each; `normalizeS` enforces low-S to avoid malleability.
+			return p256.Signature.fromDER(attestationSignature)
+				.normalizeS()
+				.toCompactRawBytes();
 		}
 
 		default:
 			curveType satisfies never;
 			throw new Error(`Unsupported curve type ${curveType}`);
 	}
-}
-
-/**
- * Specific for DER encoding of ECDSA signature.
- * Shouldn't be used for other purposes.
- */
-function shouldRemoveLeadingZero(bytes: Uint8Array): boolean {
-	// biome-ignore lint/style/noNonNullAssertion: trust me bro
-	return bytes[0] === 0x0 && (bytes[1]! & (1 << 7)) !== 0;
-}
-
-function padToLength(bytes: Uint8Array, length: number): Uint8Array {
-	if (bytes.length >= length) {
-		return bytes;
-	}
-	const padded = new Uint8Array(length);
-	padded.set(bytes, length - bytes.length);
-	return padded;
-}
-
-/**
- * Ensures the signature's s-value is in the lower half of the curve order
- * to prevent signature malleability.
- * See: https://github.com/kadenzipfel/smart-contract-vulnerabilities/blob/master/vulnerabilities/signature-malleability.md
- */
-export function normalizeSignatureS(sBytes: Uint8Array): Uint8Array {
-	const P256_N = BigInt(
-		"0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551",
-	);
-	const P256_N_HALF = P256_N >> 1n;
-
-	const sHex = hex.encode(sBytes);
-	const s = BigInt(`0x${sHex}`);
-
-	if (s > P256_N_HALF) {
-		const sLow = P256_N - s;
-		return hex.decode(sLow.toString(16).padStart(64, "0"));
-	}
-
-	return sBytes;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,15 +154,12 @@ importers:
       '@lifeomic/attempt':
         specifier: ^3.0.0
         version: 3.1.0
+      '@noble/curves':
+        specifier: ^1.4.0
+        version: 1.9.6
       '@noble/hashes':
         specifier: ^1.7.1
         version: 1.8.0
-      '@peculiar/asn1-ecc':
-        specifier: ^2.0.0
-        version: 2.3.15
-      '@peculiar/asn1-schema':
-        specifier: ^2.0.0
-        version: 2.3.15
       '@scure/base':
         specifier: ^1.0.0
         version: 1.2.6
@@ -329,24 +326,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.2.0':
     resolution: {integrity: sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.2.0':
     resolution: {integrity: sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.2.0':
     resolution: {integrity: sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.2.0':
     resolution: {integrity: sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==}
@@ -929,30 +930,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-arm64-musl@1.2.0':
     resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
     resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-gnu@1.2.0':
     resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@napi-rs/keyring-linux-x64-musl@1.2.0':
     resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
     resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
@@ -1242,15 +1248,6 @@ packages:
   '@oxc-project/types@0.108.0':
     resolution: {integrity: sha512-7lf13b2IA/kZO6xgnIZA88sq3vwrxWk+2vxf6cc+omwYCRTiA5e63Beqf3fz/v8jEviChWWmFYBwzfSeyrsj7Q==}
 
-  '@peculiar/asn1-ecc@2.3.15':
-    resolution: {integrity: sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==}
-
-  '@peculiar/asn1-schema@2.3.15':
-    resolution: {integrity: sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==}
-
-  '@peculiar/asn1-x509@2.3.15':
-    resolution: {integrity: sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==}
-
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1353,48 +1350,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.60':
     resolution: {integrity: sha512-sqI+Vdx1gmXJMsXN3Fsewm3wlt7RHvRs1uysSp//NLsCoh9ZFEUr4ZzGhWKOg6Rvf+njNu/vCsz96x7wssLejQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.59':
     resolution: {integrity: sha512-CCKEk+H+8c0WGe/8n1E20n85Tq4Pv+HNAbjP1KfUXW+01aCWSMjU56ChNrM2tvHnXicfm7QRNoZyfY8cWh7jLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-beta.60':
     resolution: {integrity: sha512-8xlqGLDtTP8sBfYwneTDu8+PRm5reNEHAuI/+6WPy9y350ls0KTFd3EJCOWEXWGW0F35ko9Fn9azmurBTjqOrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.59':
     resolution: {integrity: sha512-VlfwJ/HCskPmQi8R0JuAFndySKVFX7yPhE658o27cjSDWWbXVtGkSbwaxstii7Q+3Rz87ZXN+HLnb1kd4R9Img==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-beta.60':
     resolution: {integrity: sha512-iR4nhVouVZK1CiGGGyz+prF5Lw9Lmz30Rl36Hajex+dFVFiegka604zBwzTp5Tl0BZnr50ztnVJ30tGrBhDr8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.59':
     resolution: {integrity: sha512-kuO92hTRyGy0Ts3Nsqll0rfO8eFsEJe9dGQGktkQnZ2hrJrDVN0y419dMgKy/gB2S2o7F2dpWhpfQOBehZPwVA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-beta.60':
     resolution: {integrity: sha512-HbfNcqNeqxFjSMf1Kpe8itr2e2lr0Bm6HltD2qXtfU91bSSikVs9EWsa1ThshQ1v2ZvxXckGjlVLtah6IoslPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-beta.59':
     resolution: {integrity: sha512-PXAebvNL4sYfCqi8LdY4qyFRacrRoiPZLo3NoUmiTxm7MPtYYR8CNtBGNokqDmMuZIQIecRaD/jbmFAIDz7DxQ==}
@@ -1482,56 +1487,67 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -2105,10 +2121,6 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-
-  asn1js@3.0.6:
-    resolution: {integrity: sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==}
-    engines: {node: '>=12.0.0'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -3402,13 +3414,6 @@ packages:
 
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
-
-  pvtsutils@1.3.6:
-    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
-
-  pvutils@1.1.3:
-    resolution: {integrity: sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==}
-    engines: {node: '>=6.0.0'}
 
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
@@ -5683,26 +5688,6 @@ snapshots:
 
   '@oxc-project/types@0.108.0': {}
 
-  '@peculiar/asn1-ecc@2.3.15':
-    dependencies:
-      '@peculiar/asn1-schema': 2.3.15
-      '@peculiar/asn1-x509': 2.3.15
-      asn1js: 3.0.6
-      tslib: 2.8.1
-
-  '@peculiar/asn1-schema@2.3.15':
-    dependencies:
-      asn1js: 3.0.6
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
-  '@peculiar/asn1-x509@2.3.15':
-    dependencies:
-      '@peculiar/asn1-schema': 2.3.15
-      asn1js: 3.0.6
-      pvtsutils: 1.3.6
-      tslib: 2.8.1
-
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -6888,12 +6873,6 @@ snapshots:
       arkregex: 0.0.5
 
   array-union@2.1.0: {}
-
-  asn1js@3.0.6:
-    dependencies:
-      pvtsutils: 1.3.6
-      pvutils: 1.1.3
-      tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
@@ -8266,12 +8245,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-
-  pvtsutils@1.3.6:
-    dependencies:
-      tslib: 2.8.1
-
-  pvutils@1.1.3: {}
 
   quansync@0.2.11: {}
 


### PR DESCRIPTION
## Problem

`@peculiar/asn1-schema` keeps decorator-registered ASN.1 schema metadata in a module-singleton registry. When a consumer's dependency tree contains two copies of the package, `AsnParser.parse` reads from a different registry than the one `ECDSASigValue` registered in. The lookup misses, parsed `r`/`s` come back empty, and `extractRawSignature` returns zero bytes for every ES256 signature.

This is exactly what locked P-256 passkey users out of defuse-frontend after the Movement release: the frontend pinned `asn1-schema@2.4.0` while a bumped SDK pulled in `2.6.x`. The frontend has since dropped `@peculiar` on its side ([defuse-protocol/defuse-frontend#618](https://github.com/defuse-protocol/defuse-near/pull/618)), but this package still parses DER the same way in `makeWebAuthnMultiPayload` — the intent-signing path — so any consumer with a duplicated `asn1-schema` re-hits the bug there.

## Change

- `extractRawSignature` (p256 branch) now uses `p256.Signature.fromDER(sig).normalizeS().toCompactRawBytes()`. Behavior-equivalent to the removed code: `fromDER` strips the DER sign byte, `toCompactRawBytes` left-pads r/s to 32 bytes, `normalizeS` enforces low-S. No global state involved.
- Dropped `@peculiar/asn1-ecc` / `@peculiar/asn1-schema` deps; added `@noble/curves` (already in the tree via near-api-js/viem). `@peculiar/*` is gone from the lockfile entirely.
- Removed `normalizeSignatureS` + padding helpers — no remaining consumers, not exported from the package index.
- Added a test pinning that non-canonical DER is rejected. `fromDER` is strict; spec-compliant authenticators only emit canonical DER (https://www.w3.org/TR/webauthn-3/#sctn-signature-attestation-types), and lenient parsing is what masked the duplicate-copy breakage. All existing test vectors are canonical and pass unchanged.
- Changeset: patch.

## Verification

- `vitest`: internal-utils suite 188 passed / 1 pre-existing skip (webAuthn.test.ts 8/8)
- `tsc --noEmit` clean, `biome check` clean
- defuse-frontend additionally pins the exact multipayload signature bytes through this path in a guard test (`formatters.test.ts`, on the #618 branch), which will catch any regression here on the consumer side