### PR TITLE
feat: export QuoteOptions type from intents-sdk

### DIFF
--- a/.changeset/export-quote-options.md
+++ b/.changeset/export-quote-options.md
@@ -1,0 +1,5 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Export the `QuoteOptions` type from the package entry point

--- a/packages/intents-sdk/index.ts
+++ b/packages/intents-sdk/index.ts
@@ -48,6 +48,8 @@ export type {
 	TxNoInfo,
 	// Asset parsing
 	ParsedAssetInfo,
+	// Quote options
+	QuoteOptions,
 } from "./src/shared-types";
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Re-exports the `QuoteOptions` type from the `@defuse-protocol/intents-sdk` package entry point (`index.ts`).

The type was already defined in `src/shared-types.ts` and used in public-facing shapes — e.g. `WithdrawalParams.quoteOptions?: QuoteOptions` and several `IntentsSDK` method args — but was not importable by name. Consumers could pass a `quoteOptions` object structurally, yet couldn't annotate a variable they build separately with the `QuoteOptions` type. This closes that gap.

## Changes

- `packages/intents-sdk/index.ts`: add `QuoteOptions` to the Core Types `export type { ... }` block.
- Changeset: `minor` bump for `@defuse-protocol/intents-sdk` (additive public-API change, matching repo convention for new exports).

## Verification

- `npx tsc --noEmit` — no errors referencing `index.ts` or `QuoteOptions`.
- `pnpm biome check` — clean.