### PR TITLE
feat: add BlockchainEnum.FOGO for Omni bridge integration

### DIFF
--- a/.changeset/fair-glasses-knock.md
+++ b/.changeset/fair-glasses-knock.md
@@ -1,0 +1,6 @@
+---
+"@defuse-protocol/internal-utils": patch
+"@defuse-protocol/intents-sdk": patch
+---
+
+Add `BlockchainEnum.FOGO` for Omni-only FE integration. Uses CAIP-2 matching intents-sdk `Chains.Fogo`; not added to `PoaBridgeNetworkReference` since FOGO is Omni Bridge only.

--- a/.changeset/fair-glasses-knock.md
+++ b/.changeset/fair-glasses-knock.md
@@ -3,4 +3,4 @@
 "@defuse-protocol/intents-sdk": patch
 ---
 
-Add `BlockchainEnum.FOGO` for Omni-only FE integration. Uses CAIP-2 matching intents-sdk `Chains.Fogo`; not added to `PoaBridgeNetworkReference` since FOGO is Omni Bridge only.
+Restore `PoaBridgeNetworkReference.FOGO` (`fogo:mainnet`) for Omni bridge integration.

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge-utils.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge-utils.ts
@@ -74,7 +74,7 @@ const caip2Mapping = {
 	string,
 	(typeof poaBridge.PoaBridgeNetworkReference)[Exclude<
 		keyof typeof poaBridge.PoaBridgeNetworkReference,
-		"NEAR" | "POLYGON" | "BSC" | "MONAD"
+		"NEAR" | "POLYGON" | "BSC" | "MONAD" | "FOGO"
 	>]
 >;
 

--- a/packages/internal-utils/src/poaBridge/constants/blockchains.ts
+++ b/packages/internal-utils/src/poaBridge/constants/blockchains.ts
@@ -57,6 +57,8 @@ export const BlockchainEnum = {
 	PLASMA: "eth:9745",
 	/* SCROLL is operated by HOT bridge */
 	SCROLL: "eth:534352",
+	/* FOGO is operated by Omni bridge */
+	FOGO: "solana:CDLtwKnaCoK157uaHQDj4fHu72AyD251",
 } as const;
 
 export type BlockchainEnum =

--- a/packages/internal-utils/src/poaBridge/constants/blockchains.ts
+++ b/packages/internal-utils/src/poaBridge/constants/blockchains.ts
@@ -10,6 +10,7 @@ export const PoaBridgeNetworkReference = {
 	BITCOIN: "btc:mainnet",
 	BITCOINCASH: "bch:mainnet",
 	SOLANA: "sol:mainnet",
+	FOGO: "fogo:mainnet",
 	DOGECOIN: "doge:mainnet",
 	XRPLEDGER: "xrp:mainnet",
 	ZCASH: "zec:mainnet",
@@ -57,8 +58,6 @@ export const BlockchainEnum = {
 	PLASMA: "eth:9745",
 	/* SCROLL is operated by HOT bridge */
 	SCROLL: "eth:534352",
-	/* FOGO is operated by Omni bridge */
-	FOGO: "solana:CDLtwKnaCoK157uaHQDj4fHu72AyD251",
 } as const;
 
 export type BlockchainEnum =


### PR DESCRIPTION
Restore `PoaBridgeNetworkReference.FOGO` (`fogo:mainnet`) for Omni bridge integration. FOGO is available via BlockchainEnum through the PoaBridgeNetworkReference spread.