### PR TITLE
Dp502/skip fee quoting

### DIFF
--- a/.changeset/busy-monkeys-pump.md
+++ b/.changeset/busy-monkeys-pump.md
@@ -1,0 +1,7 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Adds ability to skip quoting of fees in bridges and remove omni bridge prefunded tokens configuration
+  - Added `quoteOptions.skip` — optional field to skip quoting fees (usefull if quotiong is impossible of asset being quoted is already on address balance).
+  - Removed `bridgeConfigs[RouteEnum.OmniBridge].prefundedNativeFeeTokens` — asset IDs whose withdrawal native fee is prefunded, `quoteOptions.skip` should be used for them.

--- a/.changeset/busy-monkeys-pump.md
+++ b/.changeset/busy-monkeys-pump.md
@@ -3,5 +3,5 @@
 ---
 
 Adds ability to skip quoting of fees in bridges and remove omni bridge prefunded tokens configuration
-  - Added `quoteOptions.skip` — optional field to skip quoting fees (usefull if quotiong is impossible of asset being quoted is already on address balance).
+  - Added `quoteOptions.skip` — optional field to skip quoting fees (usefull if quotiong is impossible or asset being quoted is already on address balance).
   - Removed `bridgeConfigs[RouteEnum.OmniBridge].prefundedNativeFeeTokens` — asset IDs whose withdrawal native fee is prefunded, `quoteOptions.skip` should be used for them.

--- a/.changeset/busy-monkeys-pump.md
+++ b/.changeset/busy-monkeys-pump.md
@@ -3,5 +3,5 @@
 ---
 
 Adds ability to skip quoting of fees in bridges and remove omni bridge prefunded tokens configuration
-  - Added `quoteOptions.skip` — optional field to skip quoting fees (usefull if quotiong is impossible or asset being quoted is already on address balance).
+  - Added `quoteOptions.skip` — optional field to skip quoting fees (useful if quoting is impossible or asset being quoted is already on address balance).
   - Removed `bridgeConfigs[RouteEnum.OmniBridge].prefundedNativeFeeTokens` — asset IDs whose withdrawal native fee is prefunded, `quoteOptions.skip` should be used for them.

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.test.ts
@@ -1,10 +1,16 @@
-import { configsByEnvironment } from "@defuse-protocol/internal-utils";
-import { describe, expect, it } from "vitest";
+import {
+	configsByEnvironment,
+	getNearNep141MinStorageBalance,
+	getNearNep141StorageBalance,
+} from "@defuse-protocol/internal-utils";
+import { describe, expect, it, vi } from "vitest";
 import {
 	InvalidDestinationAddressForWithdrawalError,
 	UnsupportedAssetIdError,
 } from "../../classes/errors";
 
+import { RouteEnum } from "../../constants/route-enum";
+import * as estimateFee from "../../lib/estimate-fee";
 import {
 	createPoaBridgeRoute,
 	createVirtualChainRoute,
@@ -19,6 +25,16 @@ import {
 	withdrawalParamsInvariant,
 } from "./aurora-engine-bridge-utils";
 import { zeroAddress } from "viem";
+
+vi.mock("@defuse-protocol/internal-utils", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@defuse-protocol/internal-utils")>();
+	return {
+		...actual,
+		getNearNep141MinStorageBalance: vi.fn(),
+		getNearNep141StorageBalance: vi.fn(),
+	};
+});
 
 describe("AuroraEngineBridge", () => {
 	describe("supports()", () => {
@@ -126,6 +142,48 @@ describe("AuroraEngineBridge", () => {
 					destinationAddress,
 				}),
 			).rejects.toThrow(InvalidDestinationAddressForWithdrawalError);
+		});
+	});
+
+	describe("estimateWithdrawalFee()", () => {
+		it("quoteOptions.skip = true: skips the fee quote but keeps the storage deposit fee", async () => {
+			const minStorageBalance = 1250000000000000000000n;
+			const userStorageBalance = 0n;
+			vi.mocked(getNearNep141MinStorageBalance).mockResolvedValue(
+				minStorageBalance,
+			);
+			vi.mocked(getNearNep141StorageBalance).mockResolvedValue(
+				userStorageBalance,
+			);
+
+			const getFeeQuoteSpy = vi
+				.spyOn(estimateFee, "getFeeQuote")
+				.mockRejectedValue(
+					new Error(
+						"getFeeQuote must not be called when quoteOptions.skip is true",
+					),
+				);
+
+			const bridge = new AuroraEngineBridge({
+				envConfig: configsByEnvironment.production,
+				// biome-ignore lint/suspicious/noExplicitAny: nearProvider not used, NEAR storage calls are mocked above
+				nearProvider: {} as any,
+			});
+
+			const result = await bridge.estimateWithdrawalFee({
+				withdrawalParams: {
+					assetId: "nep141:usdt.tether-token.near",
+					routeConfig: createVirtualChainRoute("aurora", null),
+				},
+				quoteOptions: { skip: true },
+			});
+
+			expect(getFeeQuoteSpy).not.toHaveBeenCalled();
+			expect(result.amount).toBe(minStorageBalance - userStorageBalance);
+			expect(result.quote).toBeNull();
+			expect(
+				result.underlyingFees[RouteEnum.VirtualChain]?.storageDepositFee,
+			).toBe(minStorageBalance - userStorageBalance);
 		});
 	});
 });

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
@@ -181,8 +181,7 @@ export class AuroraEngineBridge implements Bridge {
 		const feeAmount = minStorageBalance - userStorageBalance;
 
 		const feeQuote =
-			args.withdrawalParams.assetId === feeAssetId ||
-			args.quoteOptions?.skip
+			args.withdrawalParams.assetId === feeAssetId || args.quoteOptions?.skip
 				? null
 				: await getFeeQuote({
 						feeAmount,

--- a/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
+++ b/packages/intents-sdk/src/bridges/aurora-engine-bridge/aurora-engine-bridge.ts
@@ -181,7 +181,8 @@ export class AuroraEngineBridge implements Bridge {
 		const feeAmount = minStorageBalance - userStorageBalance;
 
 		const feeQuote =
-			args.withdrawalParams.assetId === feeAssetId
+			args.withdrawalParams.assetId === feeAssetId ||
+			args.quoteOptions?.skip
 				? null
 				: await getFeeQuote({
 						feeAmount,

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.test.ts
@@ -1,9 +1,11 @@
 import { configsByEnvironment } from "@defuse-protocol/internal-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
 	InvalidDestinationAddressForWithdrawalError,
 	UnsupportedAssetIdError,
 } from "../../classes/errors";
+import { RouteEnum } from "../../constants/route-enum";
+import * as estimateFee from "../../lib/estimate-fee";
 import {
 	createNearWithdrawalRoute,
 	createPoaBridgeRoute,
@@ -143,6 +145,49 @@ describe("DirectBridge", () => {
 				).rejects.toThrow(DestinationExplicitNearAccountDoesntExistError);
 			},
 		);
+	});
+
+	describe("estimateWithdrawalFee()", () => {
+		it("quoteOptions.skip = true: skips the fee quote but keeps the storage deposit fee", async () => {
+			const bridge = new DirectBridge({
+				envConfig: configsByEnvironment.production,
+				// biome-ignore lint/suspicious/noExplicitAny: nearProvider not used, storage deposit cache is seeded below
+				nearProvider: {} as any,
+			});
+
+			const getFeeQuoteSpy = vi
+				.spyOn(estimateFee, "getFeeQuote")
+				.mockRejectedValue(
+					new Error(
+						"getFeeQuote must not be called when quoteOptions.skip is true",
+					),
+				);
+
+			const minStorageBalance = 1250000000000000000000n;
+			const userStorageBalance = 0n;
+			// Pre-seed storage deposit cache so estimation does not hit the network.
+			// biome-ignore lint/complexity/useLiteralKeys: accessing private property for testing
+			bridge["storageDepositCache"].set("usdt.tether-token.nearalice.near", [
+				minStorageBalance,
+				userStorageBalance,
+			]);
+
+			const result = await bridge.estimateWithdrawalFee({
+				withdrawalParams: {
+					assetId: "nep141:usdt.tether-token.near",
+					destinationAddress: "alice.near",
+					routeConfig: createNearWithdrawalRoute(),
+				},
+				quoteOptions: { skip: true },
+			});
+
+			expect(getFeeQuoteSpy).not.toHaveBeenCalled();
+			expect(result.amount).toBe(minStorageBalance - userStorageBalance);
+			expect(result.quote).toBeNull();
+			expect(
+				result.underlyingFees[RouteEnum.NearWithdrawal]?.storageDepositFee,
+			).toBe(minStorageBalance - userStorageBalance);
+		});
 	});
 });
 

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.ts
@@ -229,7 +229,8 @@ export class DirectBridge implements Bridge {
 		const feeAmount = minStorageBalance - userStorageBalance;
 
 		const feeQuote =
-			args.withdrawalParams.assetId === feeAssetId
+			args.withdrawalParams.assetId === feeAssetId ||
+			args.quoteOptions?.skip
 				? null
 				: await getFeeQuote({
 						feeAmount,

--- a/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.ts
+++ b/packages/intents-sdk/src/bridges/direct-bridge/direct-bridge.ts
@@ -229,8 +229,7 @@ export class DirectBridge implements Bridge {
 		const feeAmount = minStorageBalance - userStorageBalance;
 
 		const feeQuote =
-			args.withdrawalParams.assetId === feeAssetId ||
-			args.quoteOptions?.skip
+			args.withdrawalParams.assetId === feeAssetId || args.quoteOptions?.skip
 				? null
 				: await getFeeQuote({
 						feeAmount,

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.test.ts
@@ -29,6 +29,7 @@ import { HotBridgeEVMChains } from "./hot-bridge-chains";
 import type { IntentPrimitive } from "../../intents/shared-types";
 import { RouteEnum } from "../../constants/route-enum";
 import type { FeeEstimation } from "../../shared-types";
+import * as estimateFee from "../../lib/estimate-fee";
 
 vi.mock("@defuse-protocol/internal-utils", async (importOriginal) => {
 	const actual =
@@ -845,6 +846,49 @@ describe("HotBridge", () => {
 			expect(getGaslessWithdrawFee).toHaveBeenCalledWith(
 				expect.objectContaining({ chain: 143, token: "native" }),
 			);
+			expect(feeEstimation).toEqual({
+				amount: 10n,
+				quote: null,
+				underlyingFees: {
+					[RouteEnum.HotBridge]: {
+						relayerFee: 10n,
+						blockNumber: 12345n,
+					},
+				},
+			});
+		});
+
+		it("quoteOptions.skip = true: skips the fee quote but keeps the relayer fee", async () => {
+			const getGaslessWithdrawFee = vi
+				.fn()
+				.mockResolvedValue({ gasPrice: 10n, blockNumber: 12345n });
+
+			const hotSdk = {
+				getGaslessWithdrawFee,
+			} as unknown as HotOmniSdk;
+
+			const bridge = new HotBridge({
+				envConfig: configsByEnvironment.production,
+				hotSdk,
+			});
+
+			const getFeeQuoteSpy = vi
+				.spyOn(estimateFee, "getFeeQuote")
+				.mockRejectedValue(
+					new Error(
+						"getFeeQuote must not be called when quoteOptions.skip is true",
+					),
+				);
+
+			const feeEstimation = await bridge.estimateWithdrawalFee({
+				withdrawalParams: {
+					assetId: TON_USDT_ASSET_ID,
+					destinationAddress: TON_DESTINATION_ADDRESS,
+				},
+				quoteOptions: { skip: true },
+			});
+
+			expect(getFeeQuoteSpy).not.toHaveBeenCalled();
 			expect(feeEstimation).toEqual({
 				amount: 10n,
 				quote: null,

--- a/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts
+++ b/packages/intents-sdk/src/bridges/hot-bridge/hot-bridge.ts
@@ -325,7 +325,9 @@ export class HotBridge implements Bridge {
 		);
 
 		const feeQuote =
-			args.withdrawalParams.assetId === feeAssetId || feeAmount === 0n
+			args.withdrawalParams.assetId === feeAssetId ||
+			feeAmount === 0n ||
+			args.quoteOptions?.skip
 				? null
 				: await getFeeQuote({
 						feeAmount,

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.test.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.test.ts
@@ -1524,8 +1524,7 @@ describe("OmniBridge", () => {
 		});
 	});
 
-	describe("prefundedNativeFeeTokens", () => {
-		// Non-subsidized Omni token; fee bypass must come from the prefunded config, not FEE_SUBSIDIZED_TOKENS.
+	describe("Prefunded token flow", () => {
 		const prefundedAssetId = "nep141:eth.bridge.near";
 
 		it("estimateWithdrawalFee skips the fee quote for a prefunded token while keeping the relayer fee", async () => {
@@ -1547,7 +1546,6 @@ describe("OmniBridge", () => {
 			const bridge = new OmniBridge({
 				envConfig: configsByEnvironment.production,
 				nearProvider,
-				bridgeConfig: { prefundedNativeFeeTokens: [prefundedAssetId] },
 			});
 
 			// Pre-seed storage deposit cache so estimation does not hit the network.
@@ -1560,6 +1558,9 @@ describe("OmniBridge", () => {
 					destinationAddress: zeroAddress,
 					routeConfig: createOmniBridgeRoute(Chains.Ethereum),
 					amount: 1_000_000n,
+				},
+				quoteOptions: {
+					skip: true,
 				},
 			});
 
@@ -1590,7 +1591,6 @@ describe("OmniBridge", () => {
 			const bridge = new OmniBridge({
 				envConfig: configsByEnvironment.production,
 				nearProvider,
-				bridgeConfig: { prefundedNativeFeeTokens: [prefundedAssetId] },
 			});
 
 			const minStoragedDeposit = 1n;
@@ -1609,6 +1609,9 @@ describe("OmniBridge", () => {
 					destinationAddress: zeroAddress,
 					routeConfig: createOmniBridgeRoute(Chains.Ethereum),
 					amount: 1_000_000n,
+				},
+				quoteOptions: {
+					skip: true,
 				},
 			});
 
@@ -1647,7 +1650,6 @@ describe("OmniBridge", () => {
 			const bridge = new OmniBridge({
 				envConfig: configsByEnvironment.production,
 				nearProvider,
-				bridgeConfig: { prefundedNativeFeeTokens: [prefundedAssetId] },
 			});
 
 			await expect(
@@ -1669,36 +1671,6 @@ describe("OmniBridge", () => {
 					routeConfig: createOmniBridgeRoute(Chains.Ethereum),
 				}),
 			).resolves.toBeUndefined();
-		});
-
-		it("validateWithdrawal rejects a zero fee amount for a token that is not prefunded", async () => {
-			const nearProvider = nearFailoverRpcProvider({
-				urls: PUBLIC_NEAR_RPC_URLS,
-			});
-
-			const bridge = new OmniBridge({
-				envConfig: configsByEnvironment.production,
-				nearProvider,
-			});
-
-			await expect(
-				bridge.validateWithdrawal({
-					assetId: prefundedAssetId,
-					amount: 1_000_000n,
-					destinationAddress: zeroAddress,
-					feeEstimation: {
-						amount: 0n,
-						quote: null,
-						underlyingFees: {
-							[RouteEnum.OmniBridge]: {
-								relayerFee: 0n,
-								storageDepositFee: 0n,
-							},
-						},
-					},
-					routeConfig: createOmniBridgeRoute(Chains.Ethereum),
-				}),
-			).rejects.toThrow("Invalid Omni Bridge fee: expected > 0");
 		});
 	});
 });

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -628,7 +628,7 @@ export class OmniBridge implements Bridge {
 		let amount = 0n;
 		let quote = null;
 		// Skip quoting when native fee = 0 and no storage deposit is needed
-		// or when fee is prefunded
+		// or when the account already holds the asset needed to cover withdrawal fees
 		if (totalAmountToQuote > 0n && !args.quoteOptions?.skip) {
 			quote = await getFeeQuote({
 				feeAmount: totalAmountToQuote,

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -27,7 +27,6 @@ import type { IntentPrimitive } from "../../intents/shared-types";
 import { Chains, type Chain } from "../../lib/caip2";
 import type {
 	Bridge,
-	BridgeConfigs,
 	FeeEstimation,
 	NearTxInfo,
 	OmniBridgeRouteConfig,
@@ -102,22 +101,17 @@ export class OmniBridge implements Bridge {
 	private tokenDecimalsCache = new TTLCache<OmniAddress, TokenDecimals>({
 		ttl: 3600000,
 	});
-	private bridgeConfig: Required<
-		NonNullable<BridgeConfigs[RouteEnum["OmniBridge"]]>
-	>;
 
 	constructor({
 		envConfig,
 		nearProvider,
 		solverRelayApiKey,
 		routeMigratedPoaTokensThroughOmniBridge,
-		bridgeConfig,
 	}: {
 		envConfig: EnvConfig;
 		nearProvider: providers.Provider;
 		solverRelayApiKey?: string;
 		routeMigratedPoaTokensThroughOmniBridge?: boolean;
-		bridgeConfig?: BridgeConfigs[RouteEnum["OmniBridge"]];
 	}) {
 		this.envConfig = envConfig;
 		this.nearProvider = nearProvider;
@@ -125,9 +119,6 @@ export class OmniBridge implements Bridge {
 		this.solverRelayApiKey = solverRelayApiKey;
 		this.routeMigratedPoaTokensThroughOmniBridge =
 			routeMigratedPoaTokensThroughOmniBridge ?? false;
-		this.bridgeConfig = {
-			prefundedNativeFeeTokens: bridgeConfig?.prefundedNativeFeeTokens ?? [],
-		};
 	}
 
 	private is(routeConfig: RouteConfig): boolean {
@@ -398,16 +389,6 @@ export class OmniBridge implements Bridge {
 		logger?: ILogger;
 		skipMinAmountValidation?: boolean;
 	}): Promise<void> {
-		const isFeeSubsidized = FEE_SUBSIDIZED_TOKENS.includes(args.assetId);
-		const isPrefundedWithdrawal =
-			this.bridgeConfig.prefundedNativeFeeTokens.includes(args.assetId);
-		if (!isFeeSubsidized && !isPrefundedWithdrawal) {
-			assert(
-				args.feeEstimation.amount > 0n,
-				`Invalid Omni Bridge fee: expected > 0, got ${args.feeEstimation.amount}`,
-			);
-		}
-
 		const assetInfo = this.makeAssetInfo(args.assetId, args.routeConfig);
 
 		assert(
@@ -483,7 +464,7 @@ export class OmniBridge implements Bridge {
 		}
 
 		const utxoChainWithdrawal = isUtxoChain(omniChainKind);
-		if (!utxoChainWithdrawal && !isFeeSubsidized) {
+		if (!utxoChainWithdrawal && !FEE_SUBSIDIZED_TOKENS.includes(args.assetId)) {
 			const relayerFee = getUnderlyingFee(
 				args.feeEstimation,
 				RouteEnum.OmniBridge,
@@ -647,13 +628,8 @@ export class OmniBridge implements Bridge {
 		let amount = 0n;
 		let quote = null;
 		// Skip quoting when native fee = 0 and no storage deposit is needed
-		// or for prefunded tokens.
-		if (
-			totalAmountToQuote > 0n &&
-			!this.bridgeConfig.prefundedNativeFeeTokens.includes(
-				args.withdrawalParams.assetId,
-			)
-		) {
+		// or when fee is prefunded
+		if (totalAmountToQuote > 0n && !args.quoteOptions?.skip) {
 			quote = await getFeeQuote({
 				feeAmount: totalAmountToQuote,
 				feeAssetId: NEAR_NATIVE_ASSET_ID,

--- a/packages/intents-sdk/src/sdk.ts
+++ b/packages/intents-sdk/src/sdk.ts
@@ -52,7 +52,6 @@ import {
 import type {
 	BatchWithdrawalResult,
 	Bridge,
-	BridgeConfigs,
 	CreateWithdrawalCompletionPromisesParams,
 	FeeEstimation,
 	IIntentsSDK,
@@ -119,7 +118,6 @@ export interface IntentsSDKConfig {
 		 */
 		routeMigratedPoaTokensThroughOmniBridge?: boolean;
 	};
-	bridgeConfigs?: BridgeConfigs;
 }
 
 export class IntentsSDK implements IIntentsSDK {
@@ -198,7 +196,6 @@ export class IntentsSDK implements IIntentsSDK {
 				solverRelayApiKey: this.solverRelayApiKey,
 				routeMigratedPoaTokensThroughOmniBridge:
 					args.features?.routeMigratedPoaTokensThroughOmniBridge,
-				bridgeConfig: args.bridgeConfigs?.[RouteEnum.OmniBridge],
 			}),
 			new DirectBridge({
 				envConfig: this.envConfig,

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -216,11 +216,19 @@ export interface IIntentsSDK {
 	): Promise<BatchWithdrawalResult>;
 }
 
+/**
+ * Options controlling the solver relay quote requested when the withdrawal asset
+ * needs to be swapped into the asset that covers withdrawal fees.
+ */
 export interface QuoteOptions {
 	waitMs?: number;
 	minWaitMs?: number;
 	maxWaitMs?: number;
 	trustedMetadata?: unknown;
+	/**
+	 * Skips quoting/swapping the withdrawal asset into the fee asset entirely.
+	 * Useful when the account already holds the asset needed to cover withdrawal fees.
+	 */
 	skip?: boolean;
 }
 

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -221,6 +221,7 @@ export interface QuoteOptions {
 	minWaitMs?: number;
 	maxWaitMs?: number;
 	trustedMetadata?: unknown;
+	skip?: boolean;
 }
 
 export interface NearTxInfo {
@@ -334,17 +335,6 @@ export interface RouteFeeStructures {
 
 	/** Internal transfers have no fees */
 	[RouteEnum.InternalTransfer]: null;
-}
-
-/**
- * Per-bridge configuration, keyed by route. Each entry is optional and tunes
- * the behaviour of a single bridge; omitting one falls back to that bridge's defaults.
- */
-export interface BridgeConfigs {
-	[RouteEnum.OmniBridge]?: {
-		/** Asset IDs of subsidized tokens whose withdrawal relayer fee is prefunded. */
-		prefundedNativeFeeTokens?: string[];
-	};
 }
 
 /**

--- a/packages/intents-sdk/src/shared-types.ts
+++ b/packages/intents-sdk/src/shared-types.ts
@@ -217,7 +217,7 @@ export interface IIntentsSDK {
 }
 
 /**
- * Options controlling the solver relay quote requested when the withdrawal asset
+ * Options controlling the solver relay quote request when the withdrawal asset
  * needs to be swapped into the asset that covers withdrawal fees.
  */
 export interface QuoteOptions {


### PR DESCRIPTION
## Why this PR is created ?

To support withdrawals of tokens when solvers can't be quoted to cover Fee expenses (wrap.near in most of the cases).

 `QuoteOptions.skip` flag can be used **NOT QUOTE** solvers.  Useful for scenarios when account already has necessary tokens to cover withdrawal expenses. (Prefunded withdrawals flow)
 
 
 ## To be discussed
1.  Naming of skip , maybe it is better to change to skipFeeQuote or assumeFeeAssetAvailable
2. Should we pass quoteOptions to processWithdrawals?
 