### PR TITLE
feat(intents-sdk): expose the Omni withdrawal calculation

### DIFF
--- a/.changeset/expose-omni-withdraw-params.md
+++ b/.changeset/expose-omni-withdraw-params.md
@@ -1,0 +1,7 @@
+---
+"@defuse-protocol/intents-sdk": minor
+---
+
+Add the entry point `@defuse-protocol/intents-sdk/omni-bridge` with
+`deriveOmniWithdrawIntentParams`, which computes the values of an Omni withdrawal without
+building the intents, plus `caip2ToChainKind` and `isUtxoChain` to build its chain argument.

--- a/packages/intents-sdk/package.json
+++ b/packages/intents-sdk/package.json
@@ -26,6 +26,16 @@
 				"types": "./dist/index.d.cts",
 				"default": "./dist/index.cjs"
 			}
+		},
+		"./omni-bridge": {
+			"import": {
+				"types": "./dist/src/bridges/omni-bridge/omni-withdraw-params.d.ts",
+				"default": "./dist/src/bridges/omni-bridge/omni-withdraw-params.js"
+			},
+			"require": {
+				"types": "./dist/src/bridges/omni-bridge/omni-withdraw-params.d.cts",
+				"default": "./dist/src/bridges/omni-bridge/omni-withdraw-params.cjs"
+			}
 		}
 	},
 	"files": [

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.test.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.test.ts
@@ -261,7 +261,7 @@ describe("createWithdrawIntentsPrimitive()", () => {
 			deriveOmniWithdrawIntentParams({
 				assetId: "nep141:eth.bridge.near",
 				destinationAddress: "0x1234567890123456789012345678901234567890",
-				amount: 1000n,
+				actualAmount: 1000n,
 				omniChainKind: ChainKind.Eth,
 				intentsContract: "intents.near",
 				feeEstimation: fees(),
@@ -282,7 +282,7 @@ describe("createWithdrawIntentsPrimitive()", () => {
 			deriveOmniWithdrawIntentParams({
 				assetId: "nep141:eth.bridge.near",
 				destinationAddress: "0x1234567890123456789012345678901234567890",
-				amount: 1000n,
+				actualAmount: 1000n,
 				omniChainKind: ChainKind.Eth,
 				intentsContract: "intents.near",
 				feeEstimation: fees({ relayerFee: 500n }),
@@ -305,7 +305,7 @@ describe("createWithdrawIntentsPrimitive()", () => {
 			deriveOmniWithdrawIntentParams({
 				assetId: "nep141:btc.bridge.near",
 				destinationAddress: "bc1qtest",
-				amount: 1000n,
+				actualAmount: 1000n,
 				omniChainKind: ChainKind.Btc,
 				intentsContract: "intents.near",
 				feeEstimation: fees({ utxoMaxGasFee: 100n, utxoProtocolFee: 50n }),
@@ -332,7 +332,7 @@ describe("createWithdrawIntentsPrimitive()", () => {
 				deriveOmniWithdrawIntentParams({
 					assetId: "nep141:btc.bridge.near",
 					destinationAddress: "bc1qtest",
-					amount: 1000n,
+					actualAmount: 1000n,
 					omniChainKind: ChainKind.Btc,
 					intentsContract: "intents.near",
 					feeEstimation: fees(),
@@ -347,7 +347,7 @@ describe("createWithdrawIntentsPrimitive()", () => {
 				deriveOmniWithdrawIntentParams({
 					assetId: "nep245:token.near:1",
 					destinationAddress: "0x1234567890123456789012345678901234567890",
-					amount: 1000n,
+					actualAmount: 1000n,
 					omniChainKind: ChainKind.Eth,
 					intentsContract: "intents.near",
 					feeEstimation: fees(),
@@ -361,7 +361,7 @@ describe("deriveOmniWithdrawIntentParams()", () => {
 	const withdrawal = {
 		assetId: "nep141:btc.bridge.near",
 		destinationAddress: "bc1qtest",
-		amount: 1000n,
+		actualAmount: 1000n,
 		omniChainKind: ChainKind.Btc,
 		intentsContract: "intents.near",
 		feeEstimation: fees({

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.test.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.test.ts
@@ -1,14 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-	caip2ToChainKind,
 	chainKindToCaip2,
 	createWithdrawIntentsPrimitive,
 	getBridgedToken,
 	getAccountOmniStorageBalance,
 	getTokenDecimals,
-	isUtxoChain,
 	validateOmniToken,
 } from "./omni-bridge-utils";
+import {
+	caip2ToChainKind,
+	deriveOmniWithdrawIntentParams,
+	isUtxoChain,
+} from "./omni-withdraw-params";
 import {
 	assert,
 	nearFailoverRpcProvider,
@@ -16,6 +19,8 @@ import {
 } from "@defuse-protocol/internal-utils";
 import { ChainKind, omniAddress } from "@omni-bridge/core";
 import { Chains } from "../../lib/caip2";
+import { RouteEnum } from "../../constants/route-enum";
+import type { FeeEstimation } from "../../shared-types";
 import { OMNI_BRIDGE_CONTRACT } from "./omni-bridge-constants";
 
 describe("validateOmniToken()", () => {
@@ -228,18 +233,40 @@ describe("isUtxoChain()", () => {
 	});
 });
 
+/** The fees of an Omni withdrawal, as `estimateWithdrawalFee` returns them. */
+function fees(
+	overrides: Partial<{
+		storageDepositFee: bigint;
+		relayerFee: bigint;
+		utxoProtocolFee: bigint;
+		utxoMaxGasFee: bigint;
+	}> = {},
+): FeeEstimation {
+	return {
+		amount: 0n,
+		quote: null,
+		underlyingFees: {
+			[RouteEnum.OmniBridge]: {
+				storageDepositFee: 0n,
+				relayerFee: 0n,
+				...overrides,
+			},
+		},
+	};
+}
+
 describe("createWithdrawIntentsPrimitive()", () => {
 	it("creates intent for EVM chain without native fee", () => {
-		const result = createWithdrawIntentsPrimitive({
-			assetId: "nep141:eth.bridge.near",
-			destinationAddress: "0x1234567890123456789012345678901234567890",
-			amount: 1000n,
-			nativeFee: 0n,
-			storageDepositAmount: 0n,
-			omniChainKind: ChainKind.Eth,
-			intentsContract: "intents.near",
-			utxoMaxGasFee: null,
-		});
+		const result = createWithdrawIntentsPrimitive(
+			deriveOmniWithdrawIntentParams({
+				assetId: "nep141:eth.bridge.near",
+				destinationAddress: "0x1234567890123456789012345678901234567890",
+				amount: 1000n,
+				omniChainKind: ChainKind.Eth,
+				intentsContract: "intents.near",
+				feeEstimation: fees(),
+			}),
+		);
 
 		expect(result).toHaveLength(1);
 		expect(result[0]).toMatchObject({
@@ -251,16 +278,16 @@ describe("createWithdrawIntentsPrimitive()", () => {
 	});
 
 	it("includes storage_deposit intent when nativeFee > 0", () => {
-		const result = createWithdrawIntentsPrimitive({
-			assetId: "nep141:eth.bridge.near",
-			destinationAddress: "0x1234567890123456789012345678901234567890",
-			amount: 1000n,
-			nativeFee: 500n,
-			storageDepositAmount: 0n,
-			omniChainKind: ChainKind.Eth,
-			intentsContract: "intents.near",
-			utxoMaxGasFee: null,
-		});
+		const result = createWithdrawIntentsPrimitive(
+			deriveOmniWithdrawIntentParams({
+				assetId: "nep141:eth.bridge.near",
+				destinationAddress: "0x1234567890123456789012345678901234567890",
+				amount: 1000n,
+				omniChainKind: ChainKind.Eth,
+				intentsContract: "intents.near",
+				feeEstimation: fees({ relayerFee: 500n }),
+			}),
+		);
 
 		expect(result).toHaveLength(2);
 		expect(result[0]).toMatchObject({
@@ -274,16 +301,16 @@ describe("createWithdrawIntentsPrimitive()", () => {
 	});
 
 	it("includes maxGasFee for Bitcoin withdrawals", () => {
-		const result = createWithdrawIntentsPrimitive({
-			assetId: "nep141:btc.bridge.near",
-			destinationAddress: "bc1qtest",
-			amount: 1000n,
-			nativeFee: 0n,
-			storageDepositAmount: 0n,
-			omniChainKind: ChainKind.Btc,
-			intentsContract: "intents.near",
-			utxoMaxGasFee: 100n,
-		});
+		const result = createWithdrawIntentsPrimitive(
+			deriveOmniWithdrawIntentParams({
+				assetId: "nep141:btc.bridge.near",
+				destinationAddress: "bc1qtest",
+				amount: 1000n,
+				omniChainKind: ChainKind.Btc,
+				intentsContract: "intents.near",
+				feeEstimation: fees({ utxoMaxGasFee: 100n, utxoProtocolFee: 50n }),
+			}),
+		);
 
 		expect(result).toHaveLength(1);
 
@@ -301,31 +328,122 @@ describe("createWithdrawIntentsPrimitive()", () => {
 
 	it("throws for Bitcoin without utxoMaxGasFee", () => {
 		expect(() =>
-			createWithdrawIntentsPrimitive({
-				assetId: "nep141:btc.bridge.near",
-				destinationAddress: "bc1qtest",
-				amount: 1000n,
-				nativeFee: 0n,
-				storageDepositAmount: 0n,
-				omniChainKind: ChainKind.Btc,
-				intentsContract: "intents.near",
-				utxoMaxGasFee: null,
-			}),
-		).toThrow("Invalid utxo max gas fee");
+			createWithdrawIntentsPrimitive(
+				deriveOmniWithdrawIntentParams({
+					assetId: "nep141:btc.bridge.near",
+					destinationAddress: "bc1qtest",
+					amount: 1000n,
+					omniChainKind: ChainKind.Btc,
+					intentsContract: "intents.near",
+					feeEstimation: fees(),
+				}),
+			),
+		).toThrow("Invalid Omni Bridge utxo max gas fee");
 	});
 
 	it("throws for non NEP-141 assets", () => {
 		expect(() =>
-			createWithdrawIntentsPrimitive({
-				assetId: "nep245:token.near:1",
-				destinationAddress: "0x1234567890123456789012345678901234567890",
-				amount: 1000n,
-				nativeFee: 0n,
-				storageDepositAmount: 0n,
-				omniChainKind: ChainKind.Eth,
-				intentsContract: "intents.near",
-				utxoMaxGasFee: null,
-			}),
+			createWithdrawIntentsPrimitive(
+				deriveOmniWithdrawIntentParams({
+					assetId: "nep245:token.near:1",
+					destinationAddress: "0x1234567890123456789012345678901234567890",
+					amount: 1000n,
+					omniChainKind: ChainKind.Eth,
+					intentsContract: "intents.near",
+					feeEstimation: fees(),
+				}),
+			),
 		).toThrow("Only NEP-141 is supported");
+	});
+});
+
+describe("deriveOmniWithdrawIntentParams()", () => {
+	const withdrawal = {
+		assetId: "nep141:btc.bridge.near",
+		destinationAddress: "bc1qtest",
+		amount: 1000n,
+		omniChainKind: ChainKind.Btc,
+		intentsContract: "intents.near",
+		feeEstimation: fees({
+			relayerFee: 500n,
+			utxoMaxGasFee: 100n,
+			utxoProtocolFee: 50n,
+		}),
+	};
+
+	it("gives the values that the SDK writes into its own intents", () => {
+		const params = deriveOmniWithdrawIntentParams({
+			...withdrawal,
+			externalId: "fixed-external-id",
+		});
+
+		const intents = createWithdrawIntentsPrimitive(
+			deriveOmniWithdrawIntentParams({
+				...withdrawal,
+				externalId: "fixed-external-id",
+			}),
+		);
+
+		const [storageDeposit, ftWithdraw] = intents;
+		assert(
+			storageDeposit != null && storageDeposit.intent === "storage_deposit",
+		);
+		assert(ftWithdraw != null && ftWithdraw.intent === "ft_withdraw");
+		assert(typeof ftWithdraw.msg === "string");
+
+		expect(storageDeposit.deposit_for_account_id).toBe(
+			params.storageDepositAccountId,
+		);
+		expect(JSON.parse(ftWithdraw.msg)).toMatchObject({
+			external_id: params.externalId,
+			recipient: params.recipient,
+			msg: params.msg,
+		});
+		expect(ftWithdraw.token).toBe(params.tokenAccountId);
+	});
+
+	it("uses the external id that you give, so you can calculate two times", () => {
+		const first = deriveOmniWithdrawIntentParams({
+			...withdrawal,
+			externalId: "fixed-external-id",
+		});
+		const second = deriveOmniWithdrawIntentParams({
+			...withdrawal,
+			externalId: "fixed-external-id",
+		});
+
+		expect(first).toEqual(second);
+		expect(first.externalId).toBe("fixed-external-id");
+	});
+
+	it("makes a new external id for each withdrawal if you give none", () => {
+		const randomUUID = vi
+			.spyOn(crypto, "randomUUID")
+			.mockReturnValueOnce("00000000-0000-4000-8000-000000000001")
+			.mockReturnValueOnce("00000000-0000-4000-8000-000000000002");
+
+		try {
+			expect(deriveOmniWithdrawIntentParams(withdrawal).externalId).toBe(
+				"00000000-0000-4000-8000-000000000001",
+			);
+			expect(deriveOmniWithdrawIntentParams(withdrawal).externalId).toBe(
+				"00000000-0000-4000-8000-000000000002",
+			);
+		} finally {
+			randomUUID.mockRestore();
+		}
+	});
+
+	it("gives no storage account if there is no native fee", () => {
+		const params = deriveOmniWithdrawIntentParams({
+			...withdrawal,
+			feeEstimation: fees({ utxoMaxGasFee: 100n, utxoProtocolFee: 50n }),
+		});
+
+		expect(params.storageDepositAccountId).toBeNull();
+		expect(params.recipient).toBe(
+			omniAddress(ChainKind.Btc, withdrawal.destinationAddress),
+		);
+		expect(params.msg).toBe('{"MaxGasFee":"100"}');
 	});
 });

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge-utils.ts
@@ -1,13 +1,11 @@
-import { assert, utils } from "@defuse-protocol/internal-utils";
+import { utils } from "@defuse-protocol/internal-utils";
 import {
 	ChainKind,
-	omniAddress,
 	isBridgeToken,
 	type OmniAddress,
 	type TokenDecimals,
 	getChain,
 } from "@omni-bridge/core";
-import { calculateStorageAccountId } from "@omni-bridge/near";
 import { Chains } from "../../lib/caip2";
 import type { Chain } from "../../lib/caip2";
 import { MIN_GAS_AMOUNT, OMNI_BRIDGE_CONTRACT } from "./omni-bridge-constants";
@@ -18,26 +16,26 @@ import type {
 	IntentStorageDeposit,
 } from "@defuse-protocol/contract-types";
 import { POA_TOKENS_MIGRATED_TO_OMNI_BRIDGE } from "../../constants/poa-tokens-migrated-to-omni-bridge";
+import type { OmniWithdrawIntentParams } from "./omni-withdraw-params";
 
-export function createWithdrawIntentsPrimitive(params: {
-	assetId: string;
-	destinationAddress: string;
-	amount: bigint;
-	nativeFee: bigint;
-	storageDepositAmount: bigint;
-	omniChainKind: ChainKind;
-	intentsContract: string;
-	utxoMaxGasFee: bigint | null;
-}): (IntentStorageDeposit | IntentFtWithdraw)[] {
-	const { contractId: tokenAccountId, standard } = utils.parseDefuseAssetId(
-		params.assetId,
-	);
-	assert(standard === "nep141", "Only NEP-141 is supported");
-	const recipient = omniAddress(
-		params.omniChainKind,
-		params.destinationAddress,
-	);
-	let msg = "";
+/**
+ * Lays a calculated withdrawal out as intents.
+ *
+ * It takes the result of `deriveOmniWithdrawIntentParams` rather than the inputs to it, so
+ * there is one calculation and no way to hand it a value that was worked out some other way.
+ * That matters most for the amount: a UTXO chain has already added its fees to it, and doing
+ * that twice would send more than the caller asked for.
+ */
+export function createWithdrawIntentsPrimitive({
+	tokenAccountId,
+	recipient,
+	msg,
+	externalId,
+	storageDepositAccountId,
+	amount,
+	nativeFee,
+	storageDepositAmount,
+}: OmniWithdrawIntentParams): (IntentStorageDeposit | IntentFtWithdraw)[] {
 	const ftWithdrawPayload: {
 		recipient: OmniAddress;
 		fee: string;
@@ -47,43 +45,18 @@ export function createWithdrawIntentsPrimitive(params: {
 	} = {
 		recipient,
 		fee: "0",
-		native_token_fee: params.nativeFee.toString(),
-		external_id: crypto.randomUUID(),
+		native_token_fee: nativeFee.toString(),
+		external_id: externalId,
 	};
-	// For withdrawals to Bitcoin and other UTXO chains we need to specify maxGasFee to the relayer
-	// that is picking up our TX and sends it to a connector (btc connector for example).
-	// Technically we can avoid specifying it in the message and relayer just takes the same value
-	// however this introduces a risk that a malicious actor can pick up this tx and submit it to the connector
-	// with a higher max gas fee value that can result in recipient getting less BTC.
-	if (isUtxoChain(params.omniChainKind)) {
-		assert(
-			params.utxoMaxGasFee !== null && params.utxoMaxGasFee > 0n,
-			`Invalid utxo max gas fee: expected > 0, got ${params.utxoMaxGasFee}`,
-		);
-		msg = JSON.stringify({
-			MaxGasFee: params.utxoMaxGasFee.toString(),
-		});
+	if (msg !== "") {
 		ftWithdrawPayload.msg = msg;
 	}
 
 	const intents: (IntentStorageDeposit | IntentFtWithdraw)[] = [];
-	if (params.nativeFee > 0n) {
+	if (storageDepositAccountId !== null) {
 		intents.push({
-			deposit_for_account_id: calculateStorageAccountId(
-				{
-					token: `near:${tokenAccountId}`,
-					amount: params.amount,
-					recipient,
-					fee: {
-						fee: 0n,
-						native_fee: params.nativeFee,
-					},
-					sender: `near:${params.intentsContract}`,
-					msg,
-				},
-				ftWithdrawPayload.external_id,
-			),
-			amount: params.nativeFee.toString(),
+			deposit_for_account_id: storageDepositAccountId,
+			amount: nativeFee.toString(),
 			contract_id: OMNI_BRIDGE_CONTRACT,
 			intent: "storage_deposit",
 		});
@@ -92,11 +65,9 @@ export function createWithdrawIntentsPrimitive(params: {
 		intent: "ft_withdraw",
 		token: tokenAccountId,
 		receiver_id: OMNI_BRIDGE_CONTRACT,
-		amount: params.amount.toString(),
+		amount: amount.toString(),
 		storage_deposit:
-			params.storageDepositAmount > 0n
-				? params.storageDepositAmount.toString()
-				: undefined,
+			storageDepositAmount > 0n ? storageDepositAmount.toString() : undefined,
 		msg: JSON.stringify(ftWithdrawPayload),
 		min_gas: MIN_GAS_AMOUNT,
 	});
@@ -108,7 +79,7 @@ export function createWithdrawIntentsPrimitive(params: {
  * Mapping between CAIP-2 chain identifiers and Omni Bridge ChainKind.
  * This serves as a single source of truth for bidirectional chain conversions.
  */
-const CHAIN_MAPPINGS: [Chain, ChainKind][] = [
+export const CHAIN_MAPPINGS: [Chain, ChainKind][] = [
 	[Chains.Ethereum, ChainKind.Eth],
 	[Chains.Base, ChainKind.Base],
 	[Chains.Arbitrum, ChainKind.Arb],
@@ -123,18 +94,8 @@ const CHAIN_MAPPINGS: [Chain, ChainKind][] = [
 	[Chains.HyperEvm, ChainKind.HlEvm],
 ];
 
-export function caip2ToChainKind(network: Chain): ChainKind | null {
-	return CHAIN_MAPPINGS.find(([chain]) => chain === network)?.[1] ?? null;
-}
-
 export function chainKindToCaip2(network: ChainKind): Chain | null {
 	return CHAIN_MAPPINGS.find(([_, kind]) => kind === network)?.[0] ?? null;
-}
-
-const UTXO_CHAINS: ChainKind[] = [ChainKind.Btc];
-
-export function isUtxoChain(network: ChainKind): boolean {
-	return UTXO_CHAINS.includes(network);
 }
 
 export function poaContractIdToChainKind(contractId: string): ChainKind | null {

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -25,7 +25,7 @@ import {
 import { BridgeNameEnum } from "../../constants/bridge-name-enum";
 import { RouteEnum } from "../../constants/route-enum";
 import type { IntentPrimitive } from "../../intents/shared-types";
-import { Chains, type Chain } from "../../lib/caip2";
+import type { Chain } from "../../lib/caip2";
 import type {
 	Bridge,
 	BridgeConfigs,
@@ -58,16 +58,19 @@ import {
 	SOL_OMNI_CONTRACT_ID,
 } from "./omni-bridge-constants";
 import {
-	caip2ToChainKind,
 	chainKindToCaip2,
 	createWithdrawIntentsPrimitive,
 	getBridgedToken,
 	getAccountOmniStorageBalance,
 	validateOmniToken,
 	getTokenDecimals,
-	isUtxoChain,
 	poaContractIdToChainKind,
 } from "./omni-bridge-utils";
+import {
+	caip2ToChainKind,
+	deriveOmniWithdrawIntentParams,
+	isUtxoChain,
+} from "./omni-withdraw-params";
 import { LRUCache } from "lru-cache";
 import { getFeeQuote } from "../../lib/estimate-fee";
 import {
@@ -310,79 +313,17 @@ export class OmniBridge implements Bridge {
 				referral: args.referral,
 			});
 		}
-		const relayerFee = getUnderlyingFee(
-			args.feeEstimation,
-			RouteEnum.OmniBridge,
-			"relayerFee",
-		);
-		assert(
-			relayerFee >= 0n,
-			`Invalid Omni bridge relayer fee: expected >= 0, got ${relayerFee}`,
-		);
-
-		let amount = args.withdrawalParams.amount;
-		let utxoMaxGasFee = null;
-		/**
-		 * UTXO withdrawals add protocol + max gas fees to the intent amount since they're paid
-		 * from the withdrawn asset, not wrap.near.
-		 *
-		 * Example with nep141:nbtc.bridge.near (made-up values):
-		 * utxoFees = 50 + 50 = 100, relayerFee = 2 (excluded; paid in wrap.near)
-		 *
-		 * feeInclusive=false:
-		 *   - amount = 4000 → intent = 4000 + 100 = 4100 → user receives 4000
-		 *
-		 * feeInclusive=true:
-		 *   - amount = 3898 (4000 − 102) → intent = 3898 + 100 = 3998 → user receives 3898
-		 **/
-		if (isUtxoChain(omniChainKind)) {
-			utxoMaxGasFee = getUnderlyingFee(
-				args.feeEstimation,
-				RouteEnum.OmniBridge,
-				"utxoMaxGasFee",
-			);
-			const utxoProtocolFee = getUnderlyingFee(
-				args.feeEstimation,
-				RouteEnum.OmniBridge,
-				"utxoProtocolFee",
-			);
-			assert(
-				utxoMaxGasFee !== undefined && utxoMaxGasFee > 0n,
-				`Invalid Omni Bridge utxo max gas fee: expected > 0, got ${utxoMaxGasFee}`,
-			);
-			assert(
-				utxoProtocolFee !== undefined && utxoProtocolFee > 0n,
-				`Invalid Omni Bridge utxo protocol fee: expected > 0, got ${utxoProtocolFee}`,
-			);
-
-			amount += utxoMaxGasFee + utxoProtocolFee;
-		}
-
-		let destinationAddress = args.withdrawalParams.destinationAddress;
-		// Omni contract only accepts lowercase bech32 addresses; uppercase/mixed-case
-		// bech32 is spec-valid but rejected on-chain. Base58 (legacy/P2SH) is left as-is.
-		if (
-			assetInfo.blockchain === Chains.Bitcoin &&
-			/^bc1/i.test(destinationAddress)
-		) {
-			destinationAddress = destinationAddress.toLowerCase();
-		}
-
 		intents.push(
-			...createWithdrawIntentsPrimitive({
-				assetId: args.withdrawalParams.assetId,
-				destinationAddress,
-				amount,
-				omniChainKind,
-				intentsContract: this.envConfig.contractID,
-				nativeFee: relayerFee,
-				storageDepositAmount: getUnderlyingFee(
-					args.feeEstimation,
-					RouteEnum.OmniBridge,
-					"storageDepositFee",
-				),
-				utxoMaxGasFee,
-			}),
+			...createWithdrawIntentsPrimitive(
+				deriveOmniWithdrawIntentParams({
+					assetId: args.withdrawalParams.assetId,
+					destinationAddress: args.withdrawalParams.destinationAddress,
+					amount: args.withdrawalParams.amount,
+					omniChainKind,
+					intentsContract: this.envConfig.contractID,
+					feeEstimation: args.feeEstimation,
+				}),
+			),
 		);
 
 		return Promise.resolve(intents);

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-bridge.ts
@@ -318,7 +318,7 @@ export class OmniBridge implements Bridge {
 				deriveOmniWithdrawIntentParams({
 					assetId: args.withdrawalParams.assetId,
 					destinationAddress: args.withdrawalParams.destinationAddress,
-					amount: args.withdrawalParams.amount,
+					actualAmount: args.withdrawalParams.amount,
 					omniChainKind,
 					intentsContract: this.envConfig.contractID,
 					feeEstimation: args.feeEstimation,

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
@@ -19,6 +19,11 @@ export type OmniWithdrawIntentParams = {
 	recipient: OmniAddress;
 	/** Empty, except for a UTXO chain. Then it contains `MaxGasFee`. */
 	msg: string;
+	/**
+	 * This value makes the storage account unique. The hash covers the rest of the transfer,
+	 * so two withdrawals that match on every field would otherwise land on one account.
+	 * `calculateStorageAccountId` throws above 64 UTF-8 bytes.
+	 */
 	externalId: string;
 	/** The account that gets the native fee. Null if there is no native fee. */
 	storageDepositAccountId: string | null;
@@ -39,7 +44,8 @@ export type OmniWithdrawIntentParams = {
  * @param params.actualAmount Net of `feeEstimation.amount`. `IntentsSDK` subtracts it for a
  * fee-inclusive withdrawal, so a caller that builds the payload itself has to do the same
  * @param params.feeEstimation Read for every fee of the route, one of which raises the amount
- * @param params.externalId Supply one to reproduce an earlier call; omitted, it is random
+ * @param params.externalId Supply one to repeat an earlier call. Omit it and the function
+ * draws a random one
  * @returns The values the `ft_withdraw` carries
  */
 export function deriveOmniWithdrawIntentParams(params: {

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
@@ -1,0 +1,156 @@
+import { assert, utils } from "@defuse-protocol/internal-utils";
+import { ChainKind, omniAddress, type OmniAddress } from "@omni-bridge/core";
+import { calculateStorageAccountId } from "@omni-bridge/near";
+import type { Chain } from "../../lib/caip2";
+import { RouteEnum } from "../../constants/route-enum";
+import { getUnderlyingFee } from "../../lib/estimate-fee";
+import type { FeeEstimation } from "../../shared-types";
+import { CHAIN_MAPPINGS } from "./omni-bridge-utils";
+
+/**
+ * The values an Omni withdrawal computes before it builds the intents.
+ *
+ * `storageDepositAccountId` is derived from `externalId`, and letter case takes part in that
+ * derivation, so recomputing any of these sends the native fee to a different account.
+ */
+export type OmniWithdrawIntentParams = {
+	/** The NEP-141 account of the asset. */
+	tokenAccountId: string;
+	recipient: OmniAddress;
+	/** Empty, except for a UTXO chain. Then it contains `MaxGasFee`. */
+	msg: string;
+	externalId: string;
+	/** The account that gets the native fee. Null if there is no native fee. */
+	storageDepositAccountId: string | null;
+	/**
+	 * The amount the `ft_withdraw` carries. A UTXO chain adds its own fees to the amount the
+	 * caller asked for, because they are paid from the asset and not from wrap.near.
+	 */
+	amount: bigint;
+	/** The relayer fee. It goes in `native_token_fee`, and the storage deposit transfers it. */
+	nativeFee: bigint;
+	/** The `storage_deposit` of the `ft_withdraw`. Zero leaves the field out. */
+	storageDepositAmount: bigint;
+};
+
+/**
+ * Computes the values of an Omni withdrawal without building the intents. `OmniBridge` calls
+ * it too, so a caller that signs the payload elsewhere gets the same numbers.
+ * @param params.feeEstimation Read for every fee of the route, one of which raises the amount
+ * @param params.externalId Supply one to reproduce an earlier call; omitted, it is random
+ * @returns The values the `ft_withdraw` carries
+ */
+export function deriveOmniWithdrawIntentParams(params: {
+	assetId: string;
+	destinationAddress: string;
+	amount: bigint;
+	omniChainKind: ChainKind;
+	intentsContract: string;
+	feeEstimation: FeeEstimation;
+	externalId?: string;
+}): OmniWithdrawIntentParams {
+	const { contractId: tokenAccountId, standard } = utils.parseDefuseAssetId(
+		params.assetId,
+	);
+	assert(standard === "nep141", "Only NEP-141 is supported");
+
+	const nativeFee = getUnderlyingFee(
+		params.feeEstimation,
+		RouteEnum.OmniBridge,
+		"relayerFee",
+	);
+	assert(
+		nativeFee >= 0n,
+		`Invalid Omni bridge relayer fee: expected >= 0, got ${nativeFee}`,
+	);
+	const storageDepositAmount = getUnderlyingFee(
+		params.feeEstimation,
+		RouteEnum.OmniBridge,
+		"storageDepositFee",
+	);
+
+	let amount = params.amount;
+	let msg = "";
+	// For withdrawals to Bitcoin and other UTXO chains we need to specify maxGasFee to the relayer
+	// that is picking up our TX and sends it to a connector (btc connector for example).
+	// Technically we can avoid specifying it in the message and relayer just takes the same value
+	// however this introduces a risk that a malicious actor can pick up this tx and submit it to the connector
+	// with a higher max gas fee value that can result in recipient getting less BTC.
+	// Example with nep141:nbtc.bridge.near (made-up values):
+	// utxoFees = 50 + 50 = 100, relayerFee = 2 (excluded; paid in wrap.near)
+	//   feeInclusive=false: amount = 4000 -> intent = 4100 -> user receives 4000
+	//   feeInclusive=true:  amount = 3898 -> intent = 3998 -> user receives 3898
+	if (isUtxoChain(params.omniChainKind)) {
+		const utxoMaxGasFee = getUnderlyingFee(
+			params.feeEstimation,
+			RouteEnum.OmniBridge,
+			"utxoMaxGasFee",
+		);
+		const utxoProtocolFee = getUnderlyingFee(
+			params.feeEstimation,
+			RouteEnum.OmniBridge,
+			"utxoProtocolFee",
+		);
+		assert(
+			utxoMaxGasFee !== undefined && utxoMaxGasFee > 0n,
+			`Invalid Omni Bridge utxo max gas fee: expected > 0, got ${utxoMaxGasFee}`,
+		);
+		assert(
+			utxoProtocolFee !== undefined && utxoProtocolFee > 0n,
+			`Invalid Omni Bridge utxo protocol fee: expected > 0, got ${utxoProtocolFee}`,
+		);
+
+		// UTXO withdrawals add protocol + max gas fees to the intent amount since they're paid
+		// from the withdrawn asset, not wrap.near.
+		amount += utxoMaxGasFee + utxoProtocolFee;
+		msg = JSON.stringify({ MaxGasFee: utxoMaxGasFee.toString() });
+	}
+
+	// Omni contract only accepts lowercase bech32 addresses; uppercase/mixed-case
+	// bech32 is spec-valid but rejected on-chain. Base58 (legacy/P2SH) is left as-is.
+	const destinationAddress =
+		params.omniChainKind === ChainKind.Btc &&
+		/^bc1/i.test(params.destinationAddress)
+			? params.destinationAddress.toLowerCase()
+			: params.destinationAddress;
+
+	const recipient = omniAddress(params.omniChainKind, destinationAddress);
+	const externalId = params.externalId ?? crypto.randomUUID();
+
+	return {
+		tokenAccountId,
+		recipient,
+		msg,
+		externalId,
+		amount,
+		nativeFee,
+		storageDepositAmount,
+		storageDepositAccountId:
+			nativeFee > 0n
+				? calculateStorageAccountId(
+						{
+							token: `near:${tokenAccountId}`,
+							amount,
+							recipient,
+							fee: {
+								fee: 0n,
+								native_fee: nativeFee,
+							},
+							sender: `near:${params.intentsContract}`,
+							msg,
+						},
+						externalId,
+					)
+				: null,
+	};
+}
+
+export function caip2ToChainKind(network: Chain): ChainKind | null {
+	return CHAIN_MAPPINGS.find(([chain]) => chain === network)?.[1] ?? null;
+}
+
+const UTXO_CHAINS: ChainKind[] = [ChainKind.Btc];
+
+export function isUtxoChain(network: ChainKind): boolean {
+	return UTXO_CHAINS.includes(network);
+}

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
@@ -44,8 +44,9 @@ export type OmniWithdrawIntentParams = {
  * @param params.actualAmount Net of `feeEstimation.amount`. `IntentsSDK` subtracts it for a
  * fee-inclusive withdrawal, so a caller that builds the payload itself has to do the same
  * @param params.feeEstimation Read for every fee of the route, one of which raises the amount
- * @param params.externalId Supply one to repeat an earlier call. Omit it and the function
- * draws a random one
+ * @param params.externalId Supply one to repeat an earlier call.
+ * `calculateStorageAccountId` throws above 64 UTF-8 bytes. Omit it and the function draws a
+ * random one
  * @returns The values the `ft_withdraw` carries
  */
 export function deriveOmniWithdrawIntentParams(params: {

--- a/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
+++ b/packages/intents-sdk/src/bridges/omni-bridge/omni-withdraw-params.ts
@@ -36,6 +36,8 @@ export type OmniWithdrawIntentParams = {
 /**
  * Computes the values of an Omni withdrawal without building the intents. `OmniBridge` calls
  * it too, so a caller that signs the payload elsewhere gets the same numbers.
+ * @param params.actualAmount Net of `feeEstimation.amount`. `IntentsSDK` subtracts it for a
+ * fee-inclusive withdrawal, so a caller that builds the payload itself has to do the same
  * @param params.feeEstimation Read for every fee of the route, one of which raises the amount
  * @param params.externalId Supply one to reproduce an earlier call; omitted, it is random
  * @returns The values the `ft_withdraw` carries
@@ -43,7 +45,7 @@ export type OmniWithdrawIntentParams = {
 export function deriveOmniWithdrawIntentParams(params: {
 	assetId: string;
 	destinationAddress: string;
-	amount: bigint;
+	actualAmount: bigint;
 	omniChainKind: ChainKind;
 	intentsContract: string;
 	feeEstimation: FeeEstimation;
@@ -69,7 +71,7 @@ export function deriveOmniWithdrawIntentParams(params: {
 		"storageDepositFee",
 	);
 
-	let amount = params.amount;
+	let amount = params.actualAmount;
 	let msg = "";
 	// For withdrawals to Bitcoin and other UTXO chains we need to specify maxGasFee to the relayer
 	// that is picking up our TX and sends it to a connector (btc connector for example).

--- a/packages/intents-sdk/tsdown.config.ts
+++ b/packages/intents-sdk/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	entry: ["index.ts"],
+	entry: ["index.ts", "src/bridges/omni-bridge/omni-withdraw-params.ts"],
 	format: ["esm", "cjs"],
 	platform: "neutral",
 	dts: true,


### PR DESCRIPTION
## Expose the Omni withdrawal calculation

This branch adds the entry point `@defuse-protocol/intents-sdk/omni-bridge`. The entry point has one function, `deriveOmniWithdrawIntentParams`. The function calculates the values of an Omni withdrawal. It does not make the intents