### PR TITLE
Dp502/rename robinhood to hood

### DIFF
--- a/.changeset/easy-wolves-obey.md
+++ b/.changeset/easy-wolves-obey.md
@@ -1,0 +1,7 @@
+---
+"@defuse-protocol/crosschain-assetid": minor
+"@defuse-protocol/internal-utils": minor
+"@defuse-protocol/intents-sdk": minor
+---
+
+Rename robinhood to hood to match deployed token prefix

--- a/packages/crosschain-assetid/src/caip2-slug-registry.json
+++ b/packages/crosschain-assetid/src/caip2-slug-registry.json
@@ -32,5 +32,5 @@
 	"starknet:SN_MAIN": "starknet",
 	"hlcore:mainnet": "hypercore",
 	"solana:CDLtwKnaCoK157uaHQDj4fHu72AyD251": "fogo",
-	"eip155:4663": "robinhood"
+	"eip155:4663": "hood"
 }

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge-utils.test.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge-utils.test.ts
@@ -81,7 +81,7 @@ describe("toPoaNetwork", () => {
 		[Chains.Movement, "movement:mainnet"],
 		[Chains.Plasma, "eth:9745"],
 		[Chains.Adi, "eth:36900"],
-		[Chains.Robinhood, "eth:4663"],
+		[Chains.Hood, "eth:4663"],
 	])("maps %s to %s", (caip2, expected) => {
 		expect(toPoaNetwork(caip2)).toBe(expected);
 	});
@@ -102,7 +102,7 @@ describe("contractIdToCaip2", () => {
 		],
 		["base.omft.near", Chains.Base],
 		["arb.omft.near", Chains.Arbitrum],
-		["hood.omft.near", Chains.Robinhood],
+		["hood.omft.near", Chains.Hood],
 		["btc.omft.near", Chains.Bitcoin],
 		["bch.omft.near", Chains.BitcoinCash],
 		["doge.omft.near", Chains.Dogecoin],

--- a/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge-utils.ts
+++ b/packages/intents-sdk/src/bridges/poa-bridge/poa-bridge-utils.ts
@@ -67,7 +67,7 @@ const caip2Mapping = {
 	[Chains.Dash]: "dash:mainnet",
 	[Chains.Plasma]: "eth:9745",
 	[Chains.Adi]: "eth:36900",
-	[Chains.Robinhood]: "eth:4663",
+	[Chains.Hood]: "eth:4663",
 } satisfies Record<
 	string,
 	(typeof poaBridge.PoaBridgeNetworkReference)[Exclude<
@@ -102,7 +102,7 @@ const tokenPrefixMapping = {
 	dash: Chains.Dash,
 	plasma: Chains.Plasma,
 	adi: Chains.Adi,
-	hood: Chains.Robinhood,
+	hood: Chains.Hood,
 };
 
 export function contractIdToCaip2(contractId: string): Chain {

--- a/packages/intents-sdk/src/lib/caip2.test.ts
+++ b/packages/intents-sdk/src/lib/caip2.test.ts
@@ -23,7 +23,7 @@ describe("CAIP2 utilities", () => {
 			expect(getEIP155ChainId(Chains.Base)).toBe(8453);
 			expect(getEIP155ChainId(Chains.Arbitrum)).toBe(42161);
 			expect(getEIP155ChainId(Chains.Polygon)).toBe(137);
-			expect(getEIP155ChainId(Chains.Robinhood)).toBe(4663);
+			expect(getEIP155ChainId(Chains.Hood)).toBe(4663);
 		});
 
 		it("should throw for non-EIP155 chain constants", () => {

--- a/packages/intents-sdk/src/lib/caip2.ts
+++ b/packages/intents-sdk/src/lib/caip2.ts
@@ -40,7 +40,7 @@ export const Chains = {
 	Abstract: "eip155:2741",
 	HyperCore: "hlcore:mainnet", // No official CAIP-2 identifier exists for HyperCore; this value is unofficial and may change.
 	HyperEvm: "eip155:999",
-	Robinhood: "eip155:4663",
+	Hood: "eip155:4663",
 } as const;
 
 export type Chain = (typeof Chains)[keyof typeof Chains];

--- a/packages/intents-sdk/src/lib/compareAddresses.ts
+++ b/packages/intents-sdk/src/lib/compareAddresses.ts
@@ -33,7 +33,7 @@ export function compareAddresses(
 			case Chains.Abstract:
 			case Chains.HyperCore:
 			case Chains.HyperEvm:
-			case Chains.Robinhood:
+			case Chains.Hood:
 				return getAddress(a) === getAddress(b);
 			case Chains.Aptos:
 			case Chains.Movement:

--- a/packages/intents-sdk/src/lib/validateAddress.ts
+++ b/packages/intents-sdk/src/lib/validateAddress.ts
@@ -91,7 +91,7 @@ export function validateAddress(address: string, blockchain: Chain): boolean {
 		case Chains.Abstract:
 		case Chains.HyperCore:
 		case Chains.HyperEvm:
-		case Chains.Robinhood:
+		case Chains.Hood:
 			return validateEthAddress(address);
 		case Chains.Aleo:
 			return validateAleoAddress(address);

--- a/packages/internal-utils/src/poaBridge/constants/blockchains.ts
+++ b/packages/internal-utils/src/poaBridge/constants/blockchains.ts
@@ -35,7 +35,7 @@ export const PoaBridgeNetworkReference = {
 	DASH: "dash:mainnet",
 	PLASMA: "eth:9745",
 	ADI: "eth:36900",
-	ROBINHOOD: "eth:4663",
+	HOOD: "eth:4663",
 } as const;
 
 export const VirtualNetworkReference = {

--- a/packages/internal-utils/src/types/base.ts
+++ b/packages/internal-utils/src/types/base.ts
@@ -24,7 +24,7 @@ export type SupportedChainName =
 	| "bsc"
 	| "hyperliquid"
 	| "cardano"
-	| "robinhood";
+	| "hood";
 
 export type SupportedBridge = "direct" | "poa" | "aurora_engine" | "hot_omni";
 


### PR DESCRIPTION
## Problem
having different token prefix and token naming can cause confusion and potential mapping issues

## Solution
Align naming to HOOD from ROBINHOOD everywhere in the sdk